### PR TITLE
Make expiryTime orm-compatible

### DIFF
--- a/src/InvitationService.ts
+++ b/src/InvitationService.ts
@@ -22,7 +22,7 @@ export interface Invitation {
   invitedUserId?: string;
   invitedUser?: User;
   state?: "pending" | "accepted" | "rejected" | "revoked";
-  expiryTime?: string;
+  expiryTime?: Date | string;
 }
 
 /**


### PR DESCRIPTION
In ORMs the expiryTime might be a `Date`. This makes it easier for end users to call the Permission service with ORM datatypes.