### PR TITLE
Add permission check for deleting clusters. Deprecate canI.

### DIFF
--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -1,5 +1,5 @@
-import type { Space, Team, User } from ".";
-import { LensPlatformClient, Roles, Actions } from ".";
+import type { Space, Team, User, K8sCluster } from ".";
+import { LensPlatformClient, Roles, Actions, K8sClusterActions } from ".";
 import { minimumOptions } from "./LensPlatformClient.test";
 
 // Current user (Owner)
@@ -53,6 +53,12 @@ const mockSpace1: Space = {
   users: [mockUser1, mockUser2, mockUser3],
   teams: [mockTeam1, mockTeam2, mockTeam3]
 };
+const mockK8sCluster1: K8sCluster = {
+  id: "mk1",
+  createdById: mockUser3.id,
+  name: "",
+  kind: "K8sCluster"
+};
 
 describe("PermissionsService", () => {
   let client: LensPlatformClient;
@@ -77,48 +83,74 @@ describe("PermissionsService", () => {
     });
   });
 
-  describe(".canI", () => {
+  describe(".canSpace", () => {
     it("recognizes owner privileges", () => {
-      expect(client.permission.canI(Actions.DeleteSpace, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.CreateTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.DeleteTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.RevokeInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.CreateInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchSpace, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1)).toBeTruthy();
     });
 
     it("recognizes admin privileges", () => {
-      expect(client.permission.canI(Actions.DeleteSpace, mockSpace1, mockUser2.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.CreateTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.DeleteTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.RevokeInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.CreateInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.PatchSpace, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser2.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser2.id)).toBeTruthy();
     });
 
     it("recognizes member privileges", () => {
-      expect(client.permission.canI(Actions.CreateInvitation, mockSpace1, mockUser3.id)).toBeTruthy();
-      expect(client.permission.canI(Actions.DeleteSpace, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.CreateTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.DeleteTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.RevokeInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchSpace, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser3.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser3.id)).toBeFalsy();
     });
 
     it("recognizes lack of privileges (random unrelated user test)", () => {
-      expect(client.permission.canI(Actions.DeleteSpace, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.CreateTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.DeleteTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.CreateInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canI(Actions.PatchSpace, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser4.id)).toBeFalsy();
+    });
+  });
+
+  describe(".canK8sCluster", () => {
+    it("user can delete cluster created by the user", () => {
+      expect(client.permission.canK8sCluster(
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser3.id)
+      ).toBeTruthy();
+    });
+
+    it("Admin can delete", () => {
+      expect(client.permission.canK8sCluster(
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser2.id)
+      ).toBeTruthy();
+    });
+
+    it("Owner can delete", () => {
+      expect(client.permission.canK8sCluster(
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser1.id)
+      ).toBeTruthy();
+    });
+
+    it("non-owner user can't delete", () => {
+      expect(client.permission.canK8sCluster(
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id)
+      ).toBeFalsy();
     });
   });
 });

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -92,6 +92,7 @@ export class Permissions {
    * @param forUserId - string userId
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
+   * @deprecated Use .canSpace instead.
    */
   canI(action: Actions, forSpace: Space, forUserId: string) {
     return this.canSpace(action, forSpace, forUserId);

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -1,6 +1,6 @@
-import { Base } from "./Base";
 import type { Space } from "./SpaceService";
 import type { Team } from "./TeamService";
+import type { K8sCluster } from "./K8sCluster";
 
 export enum Roles {
   Admin = "Admin",
@@ -20,6 +20,10 @@ export enum Actions {
   PatchTeam
 }
 
+export enum K8sClusterActions {
+  DeleteK8sCluster
+}
+
 export class Permissions {
   /**
    * Clarifies whether a given user can perform an action in a given space.
@@ -29,7 +33,7 @@ export class Permissions {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canI(action: Actions, forSpace: Space, forUserId: string) {
+  canSpace(action: Actions, forSpace: Space, forUserId: string) {
     let canI = false;
 
     switch (action) {
@@ -51,6 +55,46 @@ export class Permissions {
     }
 
     return canI;
+  }
+
+  /**
+   * Clarifies whether a given user can perform an action for a given K8sCluster.
+   * @param action - `Actions` enum value
+   * @param forSpace - Space object that must contain `{ teams: Team[] }`
+   * @param forK8sCluster - K8sCluster
+   * @param forUserId - string userId
+   * @returns boolean
+   * @throws "Could not get role for space with no teams" exception
+   */
+  canK8sCluster(action: K8sClusterActions, forSpace: Space, forK8sCluster: K8sCluster, forUserId: string) {
+    let canI = false;
+
+    switch (action) {
+      // Admin, Owner or K8sCluster creator can delete it
+      case K8sClusterActions.DeleteK8sCluster: {
+        const isOwnerAdmin = [Roles.Owner, Roles.Admin].includes(this.getRole(forSpace, forUserId));
+        canI = isOwnerAdmin || forK8sCluster.createdById === forUserId;
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown action ${action}`);
+    }
+
+    return canI;
+  }
+
+  /**
+   * DEPRECATED. WILL BE REMOVED.
+   * Clarifies whether a given user can perform an action in a given space.
+   * @param action - `Actions` enum value
+   * @param forSpace - Space object that must contain `{ teams: Team[] }`
+   * @param forUserId - string userId
+   * @returns boolean
+   * @throws "Could not get role for space with no teams" exception
+   */
+  canI(action: Actions, forSpace: Space, forUserId: string) {
+    return this.canSpace(action, forSpace, forUserId);
   }
 
   /**

--- a/src/PermissionsService.ts
+++ b/src/PermissionsService.ts
@@ -1,6 +1,7 @@
 import { Base } from "./Base";
 import type { LensPlatformClientType } from "./index";
-import { Actions, Permissions } from "./Permissions";
+import type { K8sCluster } from "./K8sCluster";
+import { Actions, K8sClusterActions, Permissions } from "./Permissions";
 import type { Space } from "./SpaceService";
 
 export class PermissionsService extends Base {
@@ -19,8 +20,34 @@ export class PermissionsService extends Base {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
+  canSpace(action: Actions, forSpace: Space, forUserId: string = this.lensPlatformClient.currentUserId) {
+    return this.permissions.canSpace(action, forSpace, forUserId);
+  }
+
+  /**
+   * Clarifies whether a given user can perform an action for a given K8sCluster.
+   * @param action - `Actions` enum value
+   * @param forSpace - Space object that must contain `{ teams: Team[] }`
+   * @param forK8sCluster - K8sCluster
+   * @param forUserId - string userId
+   * @returns boolean
+   * @throws "Could not get role for space with no teams" exception
+   */
+  canK8sCluster(action: K8sClusterActions, forSpace: Space, forK8sCluster: K8sCluster, forUserId: string = this.lensPlatformClient.currentUserId) {
+    return this.permissions.canK8sCluster(action, forSpace, forK8sCluster, forUserId);
+  }
+
+  /**
+   * DEPRECATED. WILL BE REMOVED.
+   * Clarifies whether a given user can perform an action in a given space.
+   * @param action - `Actions` enum value
+   * @param forSpace - Space object that must contain `{ teams: Team[] }`
+   * @param forUserId - string userId, defaults to the id of current access token bearer
+   * @returns boolean
+   * @throws "Could not get role for space with no teams" exception
+   */
   canI(action: Actions, forSpace: Space, forUserId: string = this.lensPlatformClient.currentUserId) {
-    return this.permissions.canI(action, forSpace, forUserId);
+    return this.canSpace(action, forSpace, forUserId);
   }
 
   /**

--- a/src/PermissionsService.ts
+++ b/src/PermissionsService.ts
@@ -45,6 +45,7 @@ export class PermissionsService extends Base {
    * @param forUserId - string userId, defaults to the id of current access token bearer
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
+   * @deprecated Use .canSpace instead.
    */
   canI(action: Actions, forSpace: Space, forUserId: string = this.lensPlatformClient.currentUserId) {
     return this.canSpace(action, forSpace, forUserId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import LensPlatformClient from "./LensPlatformClient";
-import { Roles, Actions, Permissions } from "./Permissions";
+import { Roles, Actions, K8sClusterActions, Permissions } from "./Permissions";
 import type { LensPlatformClientType, LensPlatformClientOptions } from "./LensPlatformClient";
 import type { User } from "./UserService";
 import type { Space } from "./SpaceService";
@@ -11,4 +11,4 @@ import type { OpenIdConnectUserInfo } from "./OpenIdConnect";
 
 export type { User, Space, Team, K8sCluster, Invitation, BillingPlan, OpenIdConnectUserInfo };
 export type { LensPlatformClientType, LensPlatformClientOptions };
-export { LensPlatformClient, Roles, Actions, Permissions };
+export { LensPlatformClient, Roles, Actions, K8sClusterActions, Permissions };


### PR DESCRIPTION
* Add permission check for deleting clusters.
* Deprecate canI. Please use canSpace from now on. canI will be removed at a later time.
* Export new `K8sClusterActions`