### PR TITLE
Make updating username work properly.

### DIFF
--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -59,9 +59,9 @@ class UserService extends Base {
   /**
    * Updating requires both username and email
    */
-  async updateOne(user: Except<User, "username" | "email"> & { username: string; email: string } & { attributes?: UserAttributes }): Promise<User> {
+  async updateOne(username: string, user: Except<User, "email"> & { email: string } & { attributes?: UserAttributes }): Promise<User> {
     const { apiEndpointAddress, got } = this.lensPlatformClient;
-    const url = `${apiEndpointAddress}/users/${user.username}`;
+    const url = `${apiEndpointAddress}/users/${username}`;
     const json = await got.patch(url, { json: user });
 
     return (json as unknown) as User;


### PR DESCRIPTION
At the moment the backend is ignoring the username in the endpoint. However, we should differentiate between the current username (here in the username function parameter) and the (optional) updated username in the `user` object.

This allows us later to refactor the backend to make email property optional in the user object, and use the username in the endpoint instead.