### PR TITLE
Fix Role check in Space

### DIFF
--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -22,6 +22,11 @@ const mockUser4: User = {
   id: "3"
 };
 
+// Member of Space, but not team
+const mockUser5: User = {
+  id: "4"
+};
+
 const mockTeam1: Team = {
   kind: "Owner",
   id: "mt1",
@@ -50,7 +55,7 @@ const mockSpace1: Space = {
   id: "ms1",
   name: "ms1",
   description: "ms1",
-  users: [mockUser1, mockUser2, mockUser3],
+  users: [mockUser1, mockUser2, mockUser3, mockUser5],
   teams: [mockTeam1, mockTeam2, mockTeam3]
 };
 const mockK8sCluster1: K8sCluster = {
@@ -76,6 +81,9 @@ describe("PermissionsService", () => {
       expect(client.permission.getRole(mockSpace1)).toEqual(Roles.Owner);
       expect(client.permission.getRole(mockSpace1, mockUser2.id)).toEqual(Roles.Admin);
       expect(client.permission.getRole(mockSpace1, mockUser3.id)).toEqual(Roles.Member);
+
+      // MockUser5 is Space member but is not in any team
+      expect(client.permission.getRole(mockSpace1, mockUser5.id)).toEqual(Roles.Member);
     });
 
     it("recognizes lack of role", () => {

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -118,7 +118,7 @@ export class Permissions {
       return Roles.Admin;
     }
 
-    if (space.teams?.length && space.teams.filter(t => this.isUserInTeam(t, forUserId)).length > 0) {
+    if (space.users?.map(user => user.id).includes(forUserId)) {
       return Roles.Member;
     }
 


### PR DESCRIPTION
* Fixes #66 
* Bug #66 causes member to be "None" if extension would remove it's own implementation of the Role check (which has a different implementation)