### PR TITLE
Export type

### DIFF
--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,5 +4,9 @@
         "module": "CommonJS",
         "outDir": "./dist/cjs",
         "declaration": true,
-    }
+        "rootDir": "./src",
+    },
+    "exclude": [
+        "integration-test",
+    ]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -4,5 +4,9 @@
         "module": "ES2020",
         "outDir": "./dist/esm",
         "declaration": true,
-    }
+        "rootDir": "./src",
+    },
+    "exclude": [
+        "integration-test",
+    ]
 }


### PR DESCRIPTION
`rootDir` was removed from `tsconfig.json` in this PR https://github.com/lensapp/lens-platform-sdk/pull/65 but that creates a regression for published npm module become `src/index.d.js` instead of `./index.d.js` at the root.

User will get `"Cannot find module 'lens-platform-sdk' or its corresponding type declarations.ts(2307)"` error

This PR should fix the isssue.