### PR TITLE
Implement a function for deleting a user

### DIFF
--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -94,11 +94,11 @@ class UserService extends Base {
   }
 
   async deleteOne(username: string): Promise<void> {
-    const { apiEndpointAddress, got } = this.lensPlatformClient;
+    const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/users/${username}`;
 
     await throwExpected(
-      () => got.delete(url),
+      () => fetch.delete(url),
       {
         500: error => {
           if (error?.body.message.includes("Token")) {

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -1,6 +1,15 @@
-import { TokenNotFoundException } from "../dist/cjs";
 import { Base } from "./Base";
-import { throwExpected, NotFoundException, ForbiddenException, BadRequestException, UsernameAlreadyExistsException, UnprocessableEntityException, UserNameNotFoundException, LensSDKException } from "./exceptions";
+import {
+  throwExpected,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+  UsernameAlreadyExistsException,
+  UnprocessableEntityException,
+  UserNameNotFoundException,
+  LensSDKException,
+  TokenNotFoundException
+} from "./exceptions";
 
 /**
  *

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -1,3 +1,4 @@
+import { TokenNotFoundException } from "../dist/cjs";
 import { Base } from "./Base";
 import { throwExpected, NotFoundException, ForbiddenException, BadRequestException, UsernameAlreadyExistsException, UnprocessableEntityException, UserNameNotFoundException, LensSDKException } from "./exceptions";
 
@@ -101,7 +102,7 @@ class UserService extends Base {
       {
         500: error => {
           if (error?.body.message.includes("Token")) {
-            return new NotFoundException("Token not found");
+            return new TokenNotFoundException();
           }
 
           if (error?.body.message.includes("User")) {
@@ -115,6 +116,7 @@ class UserService extends Base {
           );
         },
         403: error => new ForbiddenException(error?.body.message),
+        404: () => new UserNameNotFoundException(username),
         422: error => new UnprocessableEntityException(error?.body.message)
       }
     );

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -98,7 +98,7 @@ class UserService extends Base {
     const url = `${apiEndpointAddress}/users/${username}`;
 
     await throwExpected(
-      () => fetch.delete(url),
+      async () => fetch.delete(url),
       {
         500: error => {
           if (error?.body.message.includes("Token")) {

--- a/src/exceptions/utils.ts
+++ b/src/exceptions/utils.ts
@@ -91,7 +91,7 @@ export const throwExpected = async <T = any>(fn: () => Promise<T>, exceptionsMap
       throw mappedExceptionFn(response);
     } else {
       // Throw strongly-typed unexpected exception
-      throw new LensSDKException(errCode, "Unexpected exception [Lens Platform SDK]: " + HTTPErrorCodes[errCode], e);
+      throw new LensSDKException(errCode, `Unexpected exception [Lens Platform SDK]: ${HTTPErrorCodes[errCode]}`, e);
     }
   }
 };


### PR DESCRIPTION
Integration tests are going to be added as soon as the relevant changes are merged to Lens Platform. I'm planning only to add tests for unsuccessful user deletion (exceptional cases), - since user creation via SDK is not supported yet, I don't see any way of testing successful user deletion idempotently. 