### PR TITLE
Change userAttributes.name to just 'string'

### DIFF
--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -27,7 +27,7 @@ export interface User {
     id: string;
     userId: string;
     value: string;
-    name: "company" | "tshirt" | "fullname";
+    name: string;
   }>;
 }
 


### PR DESCRIPTION
Getting this
<img width="1101" alt="Screen Shot 2021-06-16 at 1 19 15 PM" src="https://user-images.githubusercontent.com/1474479/122202191-74d56580-cea5-11eb-9a44-85f6811a72b4.png">


when upgrade sdk from 0.0.1 to 4.0.3 in backend, I think we don't need to be that strict about `userAttributes.name`

