### PR TITLE
Add Entity types

### DIFF
--- a/src/InvitationDomain.ts
+++ b/src/InvitationDomain.ts
@@ -1,4 +1,6 @@
-import type { Space } from "./SpaceService";
+import type { Space, SpaceEntity } from "./SpaceService";
+import type { MapToEntity } from "./types/types";
+import type { Except } from "type-fest";
 
 /**
  *
@@ -16,3 +18,7 @@ export interface InvitationDomain {
   createdAt?: string;
   updatedAt?: string;
 }
+
+export type InvitationDomainEntity = Except<MapToEntity<InvitationDomain>, "space"> & {
+  space?: SpaceEntity;
+};

--- a/src/InvitationService.ts
+++ b/src/InvitationService.ts
@@ -13,6 +13,7 @@ import {
   NotFoundException
 } from "./exceptions";
 import { Except } from "type-fest";
+import type { MapToEntity } from "./types/types";
 
 export const invitationEntityKinds = ["directInvite", "emailInvite", "weblinkInvite"] as const;
 export type InvitationEntityKind = typeof invitationEntityKinds[number];
@@ -33,10 +34,7 @@ export interface Invitation {
   id?: string;
   createdBy?: User;
   createdById?: string;
-
-  // Note: this is string when fetched:
-  createdAt?: Date;
-
+  createdAt?: string;
   updatedAt?: string;
   invitedEmail?: string;
   invitedUserId?: string;
@@ -44,6 +42,8 @@ export interface Invitation {
   state?: "pending" | "accepted" | "rejected" | "revoked";
   expiryTime?: Date | string;
 }
+
+export type InvitationEntity = MapToEntity<Invitation>;
 
 /**
  *

--- a/src/K8sCluster.ts
+++ b/src/K8sCluster.ts
@@ -1,4 +1,6 @@
-import type { Space } from "./SpaceService";
+import type { Space, SpaceEntity } from "./SpaceService";
+import type { MapToEntity } from "./types/types";
+import type { Except } from "type-fest";
 
 /**
  *
@@ -26,3 +28,8 @@ export interface K8sCluster {
     message?: string;
   };
 }
+
+export type K8sClusterEntity = Except<MapToEntity<K8sCluster>, "space"> & {
+  space?: SpaceEntity;
+};
+

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -1,7 +1,6 @@
-import type { Space } from "./SpaceService";
-import type { Team } from "./TeamService";
-import type { K8sCluster } from "./K8sCluster";
-import type { Invitation } from "./InvitationService";
+import type { Space, SpaceEntity } from "./SpaceService";
+import type { Team, TeamEntity } from "./TeamService";
+import type { K8sCluster, K8sClusterEntity } from "./K8sCluster";
 
 export enum Roles {
   Admin = "Admin",
@@ -42,7 +41,7 @@ export class Permissions {
    */
   canSpace(
     action: Actions,
-    forSpace: Space,
+    forSpace: Space | SpaceEntity,
     forUserId: string,
     forRevokeInvitation?: {
       invitationId: string;
@@ -103,7 +102,7 @@ export class Permissions {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canK8sCluster(action: K8sClusterActions, forSpace: Space, forK8sCluster: K8sCluster, forUserId: string) {
+  canK8sCluster(action: K8sClusterActions, forSpace: Space | SpaceEntity, forK8sCluster: K8sCluster | K8sClusterEntity, forUserId: string) {
     let canI = false;
 
     switch (action) {
@@ -131,7 +130,7 @@ export class Permissions {
    * @throws "Could not get role for space with no teams" exception
    * @deprecated Use .canSpace instead.
    */
-  canI(action: Actions, forSpace: Space, forUserId: string) {
+  canI(action: Actions, forSpace: Space | SpaceEntity, forUserId: string) {
     return this.canSpace(action, forSpace, forUserId);
   }
 
@@ -142,7 +141,7 @@ export class Permissions {
    * @returns Role enum value
    * @throws "Could not get role for space with no teams" exception
    */
-  getRole(space: Space, forUserId: string) {
+  getRole(space: Space | SpaceEntity, forUserId: string) {
     if (!space.teams) {
       throw new Error("Could not get role for space with no teams");
     }
@@ -162,25 +161,25 @@ export class Permissions {
     return Roles.None;
   }
 
-  protected getOwnerTeams = (space: Space) => {
+  protected getOwnerTeams = (space: Space | SpaceEntity) => {
     const teams = space.teams ?? [];
 
-    return teams.filter(({ kind }) => kind === "Owner");
+    return (teams as Team[]).filter(({ kind }) => kind === "Owner");
   };
 
-  protected getAdminTeams = (space: Space) => {
+  protected getAdminTeams = (space: Space | SpaceEntity) => {
     const teams = space.teams ?? [];
 
-    return teams.filter(({ kind }) => kind === "Admin");
+    return (teams as Team[]).filter(({ kind }) => kind === "Admin");
   };
 
-  protected getNormalTeams = (space: Space) => {
+  protected getNormalTeams = (space: Space | SpaceEntity) => {
     const teams = space.teams ?? [];
 
-    return teams.filter(({ kind }) => kind === "Normal");
+    return (teams as Team[]).filter(({ kind }) => kind === "Normal");
   };
 
-  protected isUserInTeam = (team: Team, userId: string): boolean => {
+  protected isUserInTeam = (team: Team | TeamEntity, userId: string): boolean => {
     if (!team.users?.length) {
       return false;
     }

--- a/src/PermissionsService.ts
+++ b/src/PermissionsService.ts
@@ -1,9 +1,8 @@
 import { Base } from "./Base";
 import type { LensPlatformClientType } from "./index";
-import type { K8sCluster } from "./K8sCluster";
-import type { Invitation } from "./InvitationService";
+import type { K8sCluster, K8sClusterEntity } from "./K8sCluster";
 import { Actions, K8sClusterActions, Permissions } from "./Permissions";
-import type { Space } from "./SpaceService";
+import type { Space, SpaceEntity } from "./SpaceService";
 
 export class PermissionsService extends Base {
   permissions: Permissions;
@@ -22,7 +21,7 @@ export class PermissionsService extends Base {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canSpace(action: Actions, forSpace: Space, forUserId: string = this.lensPlatformClient.currentUserId, forRevokeInvitation?: {
+  canSpace(action: Actions, forSpace: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId, forRevokeInvitation?: {
     invitationId: string;
     invitationIdsCreatedByUserId: string[];
   }) {
@@ -38,7 +37,7 @@ export class PermissionsService extends Base {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canK8sCluster(action: K8sClusterActions, forSpace: Space, forK8sCluster: K8sCluster, forUserId: string = this.lensPlatformClient.currentUserId) {
+  canK8sCluster(action: K8sClusterActions, forSpace: Space | SpaceEntity, forK8sCluster: K8sCluster | K8sClusterEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
     return this.permissions.canK8sCluster(action, forSpace, forK8sCluster, forUserId);
   }
 
@@ -52,7 +51,7 @@ export class PermissionsService extends Base {
    * @throws "Could not get role for space with no teams" exception
    * @deprecated Use .canSpace instead.
    */
-  canI(action: Actions, forSpace: Space, forUserId: string = this.lensPlatformClient.currentUserId) {
+  canI(action: Actions, forSpace: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
     return this.canSpace(action, forSpace, forUserId);
   }
 
@@ -63,7 +62,7 @@ export class PermissionsService extends Base {
    * @returns Role enum value
    * @throws "Could not get role for space with no teams" exception
    */
-  getRole(space: Space, forUserId: string = this.lensPlatformClient.currentUserId) {
+  getRole(space: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
     return this.permissions.getRole(space, forUserId);
   }
 }

--- a/src/SpaceService.ts
+++ b/src/SpaceService.ts
@@ -1,10 +1,10 @@
 import { Base } from "./Base";
 import { User } from "./UserService";
-import type { Team } from "./TeamService";
+import type { Team, TeamEntity } from "./TeamService";
 import type { K8sCluster } from "./K8sCluster";
-import type { Invitation } from "./InvitationService";
+import type { Invitation, InvitationEntity } from "./InvitationService";
 import type { BillingPlan } from "./BillingPlan";
-import type { InvitationDomain } from "./InvitationDomain";
+import type { InvitationDomain, InvitationDomainEntity } from "./InvitationDomain";
 import {
   throwExpected,
   SpaceNotFoundException,
@@ -17,6 +17,8 @@ import {
   UserNameNotFoundException,
   NotFoundException
 } from "./exceptions";
+import type { MapToEntity } from "./types/types";
+import type { Except } from "type-fest";
 
 /**
  *
@@ -39,6 +41,12 @@ export interface Space {
   invitations?: Invitation[];
   invitationDomains?: InvitationDomain[];
 }
+
+export type SpaceEntity = Except<MapToEntity<Space>, "teams" | "invitations" | "invitationDomains"> & {
+  teams?: TeamEntity[];
+  invitations?: InvitationEntity[];
+  invitationDomains?: InvitationDomainEntity[];
+};
 
 /**
  *

--- a/src/TeamService.ts
+++ b/src/TeamService.ts
@@ -1,6 +1,8 @@
 import { Base } from "./Base";
-import type { Space } from "./SpaceService";
+import type { Space, SpaceEntity } from "./SpaceService";
 import type { User } from "./UserService";
+import type { MapToEntity } from "./types/types";
+import type { Except } from "type-fest";
 
 /**
  *
@@ -21,6 +23,10 @@ export interface Team {
   createdAt?: string;
   updatedAt?: string;
 }
+
+export type TeamEntity = Except<MapToEntity<Team>, "space"> & {
+  space?: SpaceEntity;
+};
 
 /**
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,18 @@ import LensPlatformClient from "./LensPlatformClient";
 import { Roles, Actions, K8sClusterActions, Permissions } from "./Permissions";
 import type { LensPlatformClientType, LensPlatformClientOptions } from "./LensPlatformClient";
 import type { User, UserAttributes } from "./UserService";
-import type { Space } from "./SpaceService";
-import type { Team } from "./TeamService";
-import type { K8sCluster } from "./K8sCluster";
-import type { Invitation } from "./InvitationService";
-import type { InvitationDomain } from "./InvitationDomain";
+import type { Space, SpaceEntity } from "./SpaceService";
+import type { Team, TeamEntity } from "./TeamService";
+import type { K8sCluster, K8sClusterEntity } from "./K8sCluster";
+import type { Invitation, InvitationEntity } from "./InvitationService";
+import type { InvitationDomain, InvitationDomainEntity } from "./InvitationDomain";
 import type { BillingPlan } from "./BillingPlan";
 import type { OpenIdConnectUserInfo } from "./OpenIdConnect";
 
-export type { User, UserAttributes, Space, InvitationDomain, Team, K8sCluster, Invitation, BillingPlan, OpenIdConnectUserInfo };
+export type {
+  User, UserAttributes, Space, InvitationDomain, Team, K8sCluster, Invitation, BillingPlan, OpenIdConnectUserInfo,
+  SpaceEntity, TeamEntity, K8sClusterEntity, InvitationEntity, InvitationDomainEntity
+};
 export type { LensPlatformClientType, LensPlatformClientOptions };
 export { LensPlatformClient, Roles, Actions, K8sClusterActions, Permissions };
 export * from "./exceptions";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,14 @@
+// Map each property to ToType for any property name in Keys
+export type MapPropsToType<Type, Keys extends keyof Type, ToType> = {
+  [Property in keyof Type]: Property extends Keys ? ToType : Type[Property]
+};
+
+// Map each property to Date for any property name in Keys
+export type MapPropsToDate<Type, Keys extends keyof Type> = MapPropsToType<Type, Keys, Date>;
+
+export interface EntityType {
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type MapToEntity<Type extends EntityType> = MapPropsToDate<Type, "createdAt" | "updatedAt">;


### PR DESCRIPTION
* Add and export Entity types
* Add type helper for creating Entity types
* SDK will now have separate types for "Dto" types and database Entity types
* Permission service will accept both for easier usage
* Fix Invitation createdAt type 

Maybe in the future we can improve the conditional mapped type to autoconvert e.g. "Space" to "SpaceEntity" in the interface.