### PR TITLE
Move @types/pino to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "MIT",
       "dependencies": {
+        "@types/pino": "^6.3.8",
         "axios": "^0.21.1",
         "jwt-decode": "^3.1.2",
         "pino": "^6.11.3"
@@ -19,7 +20,6 @@
         "@babel/preset-typescript": "^7.13.0",
         "@types/jest": "^26.0.23",
         "@types/nock": "^11.1.0",
-        "@types/pino": "^6.3.8",
         "@types/simple-oauth2": "^4.1.0",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
@@ -2217,14 +2217,12 @@
     "node_modules/@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-      "dev": true
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "node_modules/@types/pino": {
       "version": "6.3.8",
       "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.8.tgz",
       "integrity": "sha512-E47CmRy1FNMaCN8r0d8ECQOjXen9O0p6GGsUjLfmawlxRKosZ82WP1oWVKj+ikTkMDHxWzN5BuKmplo44ynrIg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/pino-pretty": "*",
@@ -2236,7 +2234,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.0.tgz",
       "integrity": "sha512-fIZ+VXf9gJoJR4tiiM7G+j/bZkPoZEfFGzA4d8tAWCTpTVyvVaBwnmdLs3wEXYpMjw8eXulrOzNCjmGHT3FgHw==",
-      "dev": true,
       "dependencies": {
         "@types/pino": "*"
       }
@@ -2245,7 +2242,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
       "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2266,7 +2262,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
       "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -10266,14 +10261,12 @@
     "@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-      "dev": true
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "@types/pino": {
       "version": "6.3.8",
       "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.8.tgz",
       "integrity": "sha512-E47CmRy1FNMaCN8r0d8ECQOjXen9O0p6GGsUjLfmawlxRKosZ82WP1oWVKj+ikTkMDHxWzN5BuKmplo44ynrIg==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/pino-pretty": "*",
@@ -10285,7 +10278,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.0.tgz",
       "integrity": "sha512-fIZ+VXf9gJoJR4tiiM7G+j/bZkPoZEfFGzA4d8tAWCTpTVyvVaBwnmdLs3wEXYpMjw8eXulrOzNCjmGHT3FgHw==",
-      "dev": true,
       "requires": {
         "@types/pino": "*"
       }
@@ -10294,7 +10286,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
       "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -10315,7 +10306,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
       "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@babel/preset-typescript": "^7.13.0",
     "@types/jest": "^26.0.23",
     "@types/nock": "^11.1.0",
-    "@types/pino": "^6.3.8",
     "@types/simple-oauth2": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
@@ -110,6 +109,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "jwt-decode": "^3.1.2",
-    "pino": "^6.11.3"
+    "pino": "^6.11.3",
+    "@types/pino": "^6.3.8"
   }
 }


### PR DESCRIPTION
so `@types/pino` will be installed when installing sdk, so user of sdk won't get `TS7016: Could not find a declaration file for module 'pino'` if not include `@types/pino` in their dependencies.