### PR TITLE
async get access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ axios.defaults.adapter = require("axios/lib/adapters/http");
 
 const lensPlatformClient = new LensPlatformClient({
     accessToken: "", // the access token for apis
-    getAccessToken: () => {}, // the callback to be called before every request, useful if the access token needs to be renew often.
+    getAccessToken: () => Promise.resolve("<token>"), // the callback to be called before every request, useful if the access token needs to be renew often.
     keyCloakAddress: "", // keycloak address, e.g. "https://keycloak.k8slens.dev"
     keycloakRealm: "", // the realm name, e.g. "lensCloud" 
     apiEndpointAddress: "", // api endpoint address, e.g. "https://api.k8slens.dev"

--- a/integration-test/UserService.test.ts
+++ b/integration-test/UserService.test.ts
@@ -81,8 +81,8 @@ describe("UserService", () => {
         .rejects.toThrowError(UnauthorizedException);
     });
 
-    it("can get users", async () => {
-      const users = await bobPlatform.client.user.getMany(`filter=email||$eq||${userBob.username}@mirantis.com`);
+    it("can get 0 users", async () => {
+      const users = await bobPlatform.client.user.getMany("filter=username||$eq||missingfoobarusername");
       expect(users.length).toEqual(0);
     });
 

--- a/integration-test/utils.ts
+++ b/integration-test/utils.ts
@@ -11,7 +11,7 @@ export class TestPlatform {
     private readonly accessToken: string
   ) {
     this.client = new LensPlatformClient({
-      getAccessToken: () => this.fakeToken ? this.fakeToken : this.accessToken,
+      getAccessToken: async () => Promise.resolve(this.fakeToken ? this.fakeToken : this.accessToken),
       keyCloakAddress: config.keyCloakAddress,
       keycloakRealm: config.keycloakRealm,
       apiEndpointAddress: config.apiEndpointAddress

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "jwt-decode": "^3.1.2",
     "pino": "^6.11.3",
     "@types/pino": "^6.3.8"
   }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "jwt-decode": "^3.1.2",
     "pino": "^6.11.3",
     "@types/pino": "^6.3.8"
   }

--- a/src/LensPlatformClient.test.ts
+++ b/src/LensPlatformClient.test.ts
@@ -89,7 +89,7 @@ describe("LensPlatformClient", () => {
       const lensPlatformClient = new LensPlatformClient({
         ...minimumOptions,
         accessToken: "",
-        getAccessToken: () => ""
+        getAccessToken: async () => Promise.resolve("")
       });
 
       const spy = jest.spyOn(axios, "get");

--- a/src/LensPlatformClient.test.ts
+++ b/src/LensPlatformClient.test.ts
@@ -36,22 +36,11 @@ describe("LensPlatformClient", () => {
     ).not.toThrow();
   });
 
-  it(".decodedAccessToken", () => {
-    const lensPlatformClient = new LensPlatformClient(minimumOptions);
-    expect(lensPlatformClient.decodedAccessToken).toEqual({ admin: true, exp: 1618486378, iat: 1618482778, jti: "b8cdf2dc-07fe-4797-b9fd-8fb9fa32dc2f", name: "John Doe", sub: "1234567890" });
-  });
-
   it(".authHeader", () => {
     const lensPlatformClient = new LensPlatformClient(minimumOptions);
     expect(lensPlatformClient.authHeader).toEqual({
       Authorization: `Bearer ${accessToken}`
     });
-  });
-
-  it(".currentUserId", () => {
-    const lensPlatformClient = new LensPlatformClient(minimumOptions);
-
-    expect(lensPlatformClient.currentUserId).toEqual("1234567890");
   });
 
   describe("proxied version of fetch", () => {

--- a/src/LensPlatformClient.ts
+++ b/src/LensPlatformClient.ts
@@ -7,6 +7,7 @@ import { InvitationService } from "./InvitationService";
 import { PlanService } from "./PlanService";
 import axios, { AxiosRequestConfig } from "axios";
 import pino from "pino";
+import decode from "jwt-decode";
 
 // Axios defaults to xhr adapter if XMLHttpRequest is available.
 // LensPlatformClient supports using the http adapter if httpAdapter
@@ -123,6 +124,16 @@ class LensPlatformClient {
     const token = this.getAccessToken && typeof this.getAccessToken === "function" ? await this.getAccessToken() : this.accessToken;
 
     return token;
+  }
+
+  async getDecodedAccessToken(): Promise<DecodedAccessToken | undefined> {
+    const token = await this.getToken();
+
+    if (token) {
+      return decode(token);
+    }
+
+    return undefined;
   }
 
   get authHeader(): Record<string, string> {

--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -81,99 +81,99 @@ describe("PermissionsService", () => {
 
   describe(".getRole", () => {
     it("recognizes Owner, Admin and Member roles", () => {
-      expect(client.permission.getRole(mockSpace1)).toEqual(Roles.Owner);
-      expect(client.permission.getRole(mockSpace1, mockUser2.id)).toEqual(Roles.Admin);
-      expect(client.permission.getRole(mockSpace1, mockUser3.id)).toEqual(Roles.Member);
+      expect(client.permission.getRole(mockSpace1, mockUser1.id!)).toEqual(Roles.Owner);
+      expect(client.permission.getRole(mockSpace1, mockUser2.id!)).toEqual(Roles.Admin);
+      expect(client.permission.getRole(mockSpace1, mockUser3.id!)).toEqual(Roles.Member);
 
       // MockUser5 is Space member but is not in any team
-      expect(client.permission.getRole(mockSpace1, mockUser5.id)).toEqual(Roles.Member);
+      expect(client.permission.getRole(mockSpace1, mockUser5.id!)).toEqual(Roles.Member);
     });
 
     it("recognizes lack of role", () => {
-      expect(client.permission.getRole(mockSpace1, mockUser4.id)).toEqual(Roles.None);
+      expect(client.permission.getRole(mockSpace1, mockUser4.id!)).toEqual(Roles.None);
     });
   });
 
   describe(".canSpace", () => {
     it("recognizes owner privileges", () => {
-      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser1.id!)).toBeTruthy();
     });
 
     it("recognizes admin privileges", () => {
-      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser2.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser2.id)).toBeTruthy();
-      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser2.id)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser2.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser2.id!)).toBeTruthy();
     });
 
     it("recognizes member privileges", () => {
-      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id, {
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id!, {
         invitationId: invitationToBeRevokedByMockUser3,
         invitationIdsCreatedByUserId: invitationIdsCreatedByMockUser3
       })).toBeTruthy();
-      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser3.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser3.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser3.id!)).toBeFalsy();
     });
 
     it("recognizes lack of privileges (random unrelated user test)", () => {
-      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser4.id)).toBeFalsy();
-      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser4.id)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteSpace, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateTeam, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteTeam, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchTeam, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchInvitation, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.CreateInvitation, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser4.id!)).toBeFalsy();
     });
   });
 
   describe(".canK8sCluster", () => {
     it("user can delete cluster created by the user", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser3.id)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser3.id!)
       ).toBeTruthy();
     });
 
     it("Admin can delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser2.id)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser2.id!)
       ).toBeTruthy();
     });
 
     it("Owner can delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser1.id)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser1.id!)
       ).toBeTruthy();
     });
 
     it("non-owner user can't delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id!)
       ).toBeFalsy();
     });
   });

--- a/src/PermissionsService.ts
+++ b/src/PermissionsService.ts
@@ -21,7 +21,7 @@ export class PermissionsService extends Base {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canSpace(action: Actions, forSpace: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId, forRevokeInvitation?: {
+  canSpace(action: Actions, forSpace: Space | SpaceEntity, forUserId: string, forRevokeInvitation?: {
     invitationId: string;
     invitationIdsCreatedByUserId: string[];
   }) {
@@ -37,7 +37,7 @@ export class PermissionsService extends Base {
    * @returns boolean
    * @throws "Could not get role for space with no teams" exception
    */
-  canK8sCluster(action: K8sClusterActions, forSpace: Space | SpaceEntity, forK8sCluster: K8sCluster | K8sClusterEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
+  canK8sCluster(action: K8sClusterActions, forSpace: Space | SpaceEntity, forK8sCluster: K8sCluster | K8sClusterEntity, forUserId: string) {
     return this.permissions.canK8sCluster(action, forSpace, forK8sCluster, forUserId);
   }
 
@@ -51,7 +51,7 @@ export class PermissionsService extends Base {
    * @throws "Could not get role for space with no teams" exception
    * @deprecated Use .canSpace instead.
    */
-  canI(action: Actions, forSpace: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
+  canI(action: Actions, forSpace: Space | SpaceEntity, forUserId: string) {
     return this.canSpace(action, forSpace, forUserId);
   }
 
@@ -62,7 +62,7 @@ export class PermissionsService extends Base {
    * @returns Role enum value
    * @throws "Could not get role for space with no teams" exception
    */
-  getRole(space: Space | SpaceEntity, forUserId: string = this.lensPlatformClient.currentUserId) {
+  getRole(space: Space | SpaceEntity, forUserId: string) {
     return this.permissions.getRole(space, forUserId);
   }
 }

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -94,7 +94,8 @@ class UserService extends Base {
   }
 
   async getSelf(): Promise<UserWithEmail> {
-    const { decodedAccessToken } = this.lensPlatformClient;
+    const decodedAccessToken = await this.lensPlatformClient.getDecodedAccessToken();
+
     if (decodedAccessToken?.preferred_username) {
       const json = await this.getOne({ username: decodedAccessToken?.preferred_username });
 


### PR DESCRIPTION
- The caller might want to provide the access token for the sdk asynchronously, which could handle e.g. refreshing an expired token before returning it. This is accomplished by making `getAccessToken` async.
- This is a major breaking change.
- I decided to remove currentUserId, because we don't want to make that async. Note that this (default) is also removed from the Permission classes.

Seems to work okay in the extension.