### PR TITLE
Add new action to restrict Space plan changes to owners

### DIFF
--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -106,6 +106,7 @@ describe("PermissionsService", () => {
       expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser1.id!)).toBeTruthy();
       expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser1.id!)).toBeTruthy();
       expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser1.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.ChangeSpacePlan, mockSpace1, mockUser1.id!)).toBeTruthy();
     });
 
     it("recognizes admin privileges", () => {
@@ -119,6 +120,7 @@ describe("PermissionsService", () => {
       expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser2.id!)).toBeTruthy();
       expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser2.id!)).toBeTruthy();
       expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser2.id!)).toBeTruthy();
+      expect(client.permission.canSpace(Actions.ChangeSpacePlan, mockSpace1, mockUser2.id!)).toBeFalsy();
     });
 
     it("recognizes member privileges", () => {
@@ -137,6 +139,7 @@ describe("PermissionsService", () => {
       expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser3.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser3.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser3.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.ChangeSpacePlan, mockSpace1, mockUser3.id!)).toBeFalsy();
     });
 
     it("recognizes lack of privileges (random unrelated user test)", () => {
@@ -149,6 +152,7 @@ describe("PermissionsService", () => {
       expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser4.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser4.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.DeleteInvitationDomain, mockSpace1, mockUser4.id!)).toBeFalsy();
+      expect(client.permission.canSpace(Actions.ChangeSpacePlan, mockSpace1, mockUser4.id!)).toBeFalsy();
     });
   });
 

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -22,7 +22,8 @@ export enum Actions {
   DeleteInvitationDomain,
   CreateTeam,
   DeleteTeam,
-  PatchTeam
+  PatchTeam,
+  ChangeSpacePlan
 }
 
 export enum K8sClusterActions {
@@ -51,6 +52,7 @@ export class Permissions {
     let canI = false;
 
     switch (action) {
+      case Actions.ChangeSpacePlan:
       case Actions.DeleteSpace:
         canI = this.getRole(forSpace, forUserId) === Roles.Owner;
         break;


### PR DESCRIPTION
Add new action for changing billing plans - needs to be Space Owner.

Signed-off-by: Steve Richards <srichards@mirantis.com>