### PR TITLE
Fix dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-test.yaml
+++ b/.github/workflows/dependabot-test.yaml
@@ -1,16 +1,16 @@
 #
-#   This CI triggered on PRs.
+#   This CI triggered on Dependabot PRs.
 #
 #   1. Runs `npm test`, which includes lint, type-checking, and unit tests on node.js LTS 10,12,14
 #      and the current version (v15)
 #
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
-  test:
+  dependabot-test:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     env:
       STAGING_USERNAME_1: ${{ secrets.STAGING_USERNAME_1 }}
       STAGING_PASSWORD_1: ${{ secrets.STAGING_PASSWORD_1 }}


### PR DESCRIPTION
This should make dependabot PRs succeed.

`pull_request` workflows for external PRs lack access to secrets, which makes the tests fail. This PR adds a new workflow for tests which is only executed for dependabot, which has access to secrets.