### PR TITLE
Update dependencies, fix lint errors from updated lint rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,36 +6,35 @@
   "packages": {
     "": {
       "name": "lens-platform-sdk",
-      "version": "8.1.1",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/pino": "^6.3.8",
-        "axios": "^0.21.1",
+        "axios": "^0.24.0",
         "jwt-decode": "^3.1.2",
-        "pino": "^6.11.3"
+        "pino": "^7.5.0"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.13.15",
         "@babel/preset-env": "^7.13.15",
         "@babel/preset-react": "^7.13.13",
         "@babel/preset-typescript": "^7.13.0",
-        "@types/jest": "^26.0.23",
+        "@types/jest": "^27.0.3",
         "@types/nock": "^11.1.0",
         "@types/simple-oauth2": "^4.1.0",
-        "@typescript-eslint/eslint-plugin": "^4.22.0",
-        "@typescript-eslint/parser": "^4.22.0",
+        "@typescript-eslint/eslint-plugin": "^5.5.0",
+        "@typescript-eslint/parser": "^5.5.0",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "dotenv": "^10.0.0",
-        "eslint": "^7.24.0",
-        "eslint-config-xo": "^0.38.0",
-        "eslint-config-xo-typescript": "^0.38.0",
+        "eslint": "^8.3.0",
+        "eslint-config-xo": "^0.39.0",
+        "eslint-config-xo-typescript": "^0.47.1",
         "eslint-plugin-tsdoc": "^0.2.14",
-        "jest": "^27.0.4",
-        "nock": "^13.0.11",
+        "jest": "^27.4.2",
+        "nock": "^13.2.1",
         "npm-run-all": "^4.1.5",
         "simple-oauth2": "^4.2.0",
-        "type-fest": "^2.3.4",
-        "typescript": "^4.2.4"
+        "type-fest": "^2.7.0",
+        "typescript": "^4.5.2"
       },
       "engines": {
         "node": ">=12 <=16"
@@ -1786,23 +1785,23 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
+        "debug": "^4.3.2",
+        "espree": "^9.0.0",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
@@ -1883,9 +1882,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -1918,6 +1917,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1937,16 +1958,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.0.tgz",
-      "integrity": "sha512-2m7Xwcd1zTWtai5DCl+b0TAfoH8p5uqUoKmfzJCAfCrIwoJAf3xB+4nx3eKEGoyNfg5oavrh3gjbZ1n5z5eh4Q==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.2.tgz",
+      "integrity": "sha512-xknHThRsPB/To1FUbi6pCe43y58qFC03zfb6R7fDb/FfC7k2R3i1l+izRBJf8DI46KhYGRaF14Eo9A3qbBoixg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-message-util": "^27.4.2",
+        "jest-util": "^27.4.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -2024,35 +2045,35 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.0.tgz",
-      "integrity": "sha512-P6eoNIbE0OeenvCxrwdj0jRgeZg8r4eXNCS2zMgAS8EADzdp03mKe7TNwCsEPr460QIYCBwJo4W8wqai3UPXOA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.2.tgz",
+      "integrity": "sha512-0mPM61tDbu8yc9CMKH9bvV+g+17VUpdWQtU1x6P1gk4AKj8iywWi8zBmEIl7pTGjUtYA92CNc/LlBfKCioBOow==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.4.0",
-        "@jest/reporters": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/reporters": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.4.0",
-        "jest-config": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-message-util": "^27.4.0",
+        "jest-changed-files": "^27.4.2",
+        "jest-config": "^27.4.2",
+        "jest-haste-map": "^27.4.2",
+        "jest-message-util": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-resolve-dependencies": "^27.4.0",
-        "jest-runner": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
-        "jest-watcher": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-resolve-dependencies": "^27.4.2",
+        "jest-runner": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
+        "jest-watcher": "^27.4.2",
         "micromatch": "^4.0.4",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
@@ -2141,62 +2162,62 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.0.tgz",
-      "integrity": "sha512-7HJ1c6lVNuxrj9PT5AD4yVDDqFt9B0lLsshxZJXShL/LOkLnBO4MoZMH3w1lXQJY3zxk3/l1yg2j7uRKpxF4yw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.2.tgz",
+      "integrity": "sha512-uSljKxh/rGlHlmhyeG4ZoVK9hOec+EPBkwTHkHKQ2EqDu5K+MaG9uJZ8o1CbRsSdZqSuhXvJCYhBWsORPPg6qw==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.4.0"
+        "jest-mock": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.0.tgz",
-      "integrity": "sha512-oyMxDKlj/ThRms9eS0xFkxmUvjJ8lHsNS4gNErDRFSruTER1/OQi2L5N0sJav+/AcBoY/Pa313CpB6RgdDacGA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.2.tgz",
+      "integrity": "sha512-f/Xpzn5YQk5adtqBgvw1V6bF8Nx3hY0OIRRpCvWcfPl0EAjdqWPdhH3t/3XpiWZqtjIEHDyMKP9ajpva1l4Zmg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.4.0",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0"
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.0.tgz",
-      "integrity": "sha512-jIkd2RSV18wvOqFx5climVkwONuxqNKD8jHMvIumj8+E0qqWqymBcWymidjbxmJ3L3Zr60l0lAJGKw0BstREeQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.2.tgz",
+      "integrity": "sha512-KkfaHEttlGpXYAQTZHgrESiEPx2q/DKAFLGLFda1uGVrqc17snd3YVPhOxlXOHIzVPs+lQ/SDB2EIvxyGzb3Ew==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.4.0",
-        "@jest/types": "^27.4.0",
-        "expect": "^27.4.0"
+        "@jest/environment": "^27.4.2",
+        "@jest/types": "^27.4.2",
+        "expect": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.0.tgz",
-      "integrity": "sha512-QqIdI9WBH5tBwSHZ81FEZkt3h8fvw+zdV0YQrUtdEbJEBGV/AHgRsIP23sdD/ybLfRFpjZJEyWT+7dM4mxnPYQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.2.tgz",
+      "integrity": "sha512-sp4aqmdBJtjKetEakzDPcZggPcVIF6w9QLkYBbaWDV6e/SIsHnF1S4KtIH91eEc2fp7ep6V/e1xvdfEoho1d2w==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -2208,10 +2229,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2333,13 +2354,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.0.tgz",
-      "integrity": "sha512-/RiwMUC9pKK1E85CEflPvb4uE4Zo9JK2Iq3RbkbBoj4FkEASb/Zsqta8WGot2J1GxOk3rqdW513tfSDYQQJVpA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.2.tgz",
+      "integrity": "sha512-kr+bCrra9jfTgxHXHa2UwoQjxvQk3Am6QbpAiJ5x/50LW8llOYrxILkqY0lZRW/hu8FXesnudbql263+EW9iNA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -2348,36 +2369,36 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.0.tgz",
-      "integrity": "sha512-yKu+sjFgelc5zUf0kcbbsO86qV0NIMPyYFFRaWTaEsq+j7aueX/Zev+NcX+bm7BCwCMWeK7V5AUE6HUOblylHA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.2.tgz",
+      "integrity": "sha512-HmHp5mlh9f9GyNej5yCS1JZIFfUGnP9+jEOH5zoq5EmsuZeYD+dGULqyvGDPtuzzbyAFJ6R4+z4SS0VvnFwwGQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
-        "jest-runtime": "^27.4.0"
+        "jest-haste-map": "^27.4.2",
+        "jest-runtime": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.0.tgz",
-      "integrity": "sha512-/8Cb8kEoCtXN/Co5lvv+jG0zv4Uj3ruIvffYUzxNGRGmM7qqaHtOBZ3WbH0T1Nvjya5utTA4YtwbInZVS6Zt9A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.2.tgz",
+      "integrity": "sha512-RTKcPZllfcmLfnlxBya7aypofhdz05+E6QITe55Ex0rxyerkgjmmpMlvVn11V0cP719Ps6WcDYCnDzxnnJUwKg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -2468,9 +2489,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.0.tgz",
-      "integrity": "sha512-jIsLdASXMf8GS7P7oGFGwobNse/6Ewq3GBPHoo0i6XRmja+NrUoDqJm4a1ffF2bHGleKJizxokcp1sCqSktP3g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2742,13 +2763,13 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
+      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
       "dev": true,
       "dependencies": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -2781,41 +2802,14 @@
     "node_modules/@types/node": {
       "version": "16.11.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
-      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw=="
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
+      "dev": true
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
-    },
-    "node_modules/@types/pino": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
-      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/pino-pretty": "*",
-        "@types/pino-std-serializers": "*",
-        "sonic-boom": "^2.1.0"
-      }
-    },
-    "node_modules/@types/pino-pretty": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
-      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/pino": "6.3"
-      }
-    },
-    "node_modules/@types/pino-std-serializers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
-      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/prettier": {
       "version": "2.4.2",
@@ -2857,30 +2851,30 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/experimental-utils": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2904,20 +2898,20 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz",
+      "integrity": "sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/typescript-estree": "5.5.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2927,44 +2921,26 @@
         "eslint": "*"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.5.0.tgz",
+      "integrity": "sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/typescript-estree": "5.5.0",
+        "debug": "^4.3.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2973,16 +2949,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
+      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/visitor-keys": "5.5.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2990,12 +2966,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==",
       "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3003,21 +2979,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz",
+      "integrity": "sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/visitor-keys": "5.5.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3045,16 +3021,16 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
+      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.5.0",
+        "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3068,9 +3044,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3087,6 +3063,18 @@
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3206,27 +3194,15 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3247,11 +3223,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/babel-code-frame": {
@@ -3350,13 +3326,13 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.0.tgz",
-      "integrity": "sha512-4855S+YT4Hx0OiXFDBOWhrMj1Y9zYE7StlchuZtr1vbo1LEDBIkt8U6+7cse8jkpJSV98w3nBVDrPgol5Ab/cQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.2.tgz",
+      "integrity": "sha512-MADrjb3KBO2eyZCAc6QaJg6RT5u+6oEdDyHO5HEalnpwQ6LrhTsQF2Kj1Wnz2t6UPXIXPk18dSXXOT0wF5yTxA==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
         "babel-preset-jest": "^27.4.0",
@@ -4077,12 +4053,12 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
+      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
       "dev": true,
       "engines": {
-        "node": ">= 10.14.2"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -4139,6 +4115,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.5.tgz",
@@ -4162,6 +4149,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -4346,37 +4341,36 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.3.0.tgz",
+      "integrity": "sha512-aIay56Ph6RxOTC7xyr59Kt3ewX185SaGnAr8eWukoPLeriCrvGjvAubxuvaXOfsxhtwV5g0uBOsyhAom4qJdww==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
+        "@eslint/eslintrc": "^1.0.4",
+        "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
+        "eslint-scope": "^7.1.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.1.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
+        "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -4384,11 +4378,10 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -4396,16 +4389,16 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-xo": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.38.0.tgz",
-      "integrity": "sha512-G2jL+VyfkcZW8GoTmqLsExvrWssBedSoaQQ11vyhflDeT3csMdBVp0On+AVijrRuvgmkWeDwwUL5Rj0qDRHK6g==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.39.0.tgz",
+      "integrity": "sha512-QX+ZnQgzy/UtgF8dksIiIBzpYoEKmiL0CmZ8O0Gnby7rGXg8Cny1CXirmHp1zKYIpO7BuTmtWj8eUYOsGr0IGQ==",
       "dev": true,
       "dependencies": {
         "confusing-browser-globals": "1.0.10"
@@ -4421,20 +4414,20 @@
       }
     },
     "node_modules/eslint-config-xo-typescript": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.38.0.tgz",
-      "integrity": "sha512-f5z0gN1r9X84PK1qav6T6YT1zW6KcAqtsMPtmqoKBLt4ACRr6tbAddtFwqkluAEH9JvHjWxuB8vu4KJFcjuzdQ==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.47.1.tgz",
+      "integrity": "sha512-BkbzIltZCWp8QLekKJKG8zJ/ZGezD8Z9FaJ+hJ5PrAVUGkIPmxXLLEHCKS3ax7oOqZLYQiG+jyKfQDIEdTQgbg==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=4.14.0",
-        "eslint": ">=7.8.0",
-        "typescript": ">=3.6.0"
+        "@typescript-eslint/eslint-plugin": ">=5.0.0",
+        "eslint": ">=8.0.0",
+        "typescript": ">=4.4"
       }
     },
     "node_modules/eslint-plugin-tsdoc": {
@@ -4461,30 +4454,24 @@
       }
     },
     "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
@@ -4493,13 +4480,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
       "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -4561,6 +4548,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/globals": {
@@ -4636,26 +4645,17 @@
       }
     },
     "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.1.0.tgz",
+      "integrity": "sha512-ZgYLvCS1wxOczBYGcQT9DDWgicXwJ4dbocr9uYN+/eresBAUuBu+O4WzB21ufQ/JqQT8gyp7hJ3z8SHii32mTQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^7.4.0",
+        "acorn": "^8.6.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "eslint-visitor-keys": "^3.1.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/esprima": {
@@ -4764,16 +4764,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.0.tgz",
-      "integrity": "sha512-3V4Nq5E5dS7bzFfinUThG0OnOnNIDdEPC0KG1pBgB1Z7ZTDVuuyvSBTOQewi0z0vaGKWPaJ880tGI+pPm+5aCg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.2.tgz",
+      "integrity": "sha512-BjAXIDC6ZOW+WBFNg96J22D27Nq5ohn+oGcuP2rtOtcjuxNoV9McpQ60PcQWhdFOSBIQdR72e+4HdnbZTFSTyg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
         "jest-regex-util": "^27.4.0"
       },
       "engines": {
@@ -4814,6 +4814,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4833,11 +4845,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastify-warning": {
       "version": "0.2.0",
@@ -4911,11 +4918,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
       "version": "3.2.4",
@@ -5001,7 +5003,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5078,15 +5079,15 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
@@ -5337,8 +5338,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-      "integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.0.tgz",
+      "integrity": "sha512-rgeP8yMlXeH4mfd9K/sQXZv1lvcS7xo379zntcotPDdMwkcGYwMxGHGZYo0/+YW5B/nor2YGKz2BH5ume405ow==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -5704,14 +5704,14 @@
       }
     },
     "node_modules/jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.0.tgz",
-      "integrity": "sha512-54SYE6EmGRoHS+9/OCspbb7tAD2WYAvBBXmny2Zp39/QgnNIWZD4KujhAZyRXHWASTBa9/WfXM2oekNBIOFV2A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.2.tgz",
+      "integrity": "sha512-TAReynFYCfHNcrL+8Z74WPGafLFLF++bGkrpcsk6cO5G9S2VuJGhu2c44YFForMgF0GlYmtbpmeznkvZpNgTxg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.4.0",
+        "@jest/core": "^27.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.4.0"
+        "jest-cli": "^27.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5729,12 +5729,12 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.0.tgz",
-      "integrity": "sha512-TacYni8ZumaB10L/fGRH92MbLYkn+MF2KtgHeAOcwnOzfmt+S6CDmJeslZuLOpnRUQKkV/Vr4qPAlrBTE5r67A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.2.tgz",
+      "integrity": "sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       },
@@ -5743,27 +5743,27 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.0.tgz",
-      "integrity": "sha512-WYmHSsuH82HZqOHPU1vD2AKyzUp5t/0R7jT1XJ8ga+hIGR5Ddv6PUQeMJvjnftyLC0izSm3tZaIYB+H6FfYqZA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.2.tgz",
+      "integrity": "sha512-2ePUSru1BGMyzxsMvRfu+tNb+PW60rUyMLJBfw1Nrh5zC8RoTPfF+zbE0JToU31a6ZVe4nnrNKWYRzlghAbL0A==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
@@ -5830,33 +5830,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-circus/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5870,21 +5843,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.0.tgz",
-      "integrity": "sha512-cTL2ORt/ha+x6KJfVp0oTAyPmHVw7IJ+lA3kmT/kNcWoCiKa+t/JlF5x+nJ0UfL3/IQLV+ysYgu8MjGM8WXH+w==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.2.tgz",
+      "integrity": "sha512-Ex2WhCj4s0XFntTKTnyLgV/CZKgQaZBYrKz02XOZ4nUjFD+26Fji/M1SgHm+2IWEIsQqoipNRx9RJH56p8d7MQ==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/core": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-config": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "prompts": "^2.0.1",
         "yargs": "^16.2.0"
       },
@@ -5974,32 +5947,32 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.0.tgz",
-      "integrity": "sha512-4ZDJd0HLX4snqDNOQYswMjQj7d7I2Bm8+TYIytDcRSAy7mkneQCKHBJu2NtIuzXxAoS2Sy+sjZ1UX/9L06zZCQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.2.tgz",
+      "integrity": "sha512-2vKqelsfHPnIzrPTpE9hImqxZLp5l9Vszpci19RdVB2i5OwoM+OkPExZMQb8aGrpEGXoKtlzvdqCL1GObiz8JQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.4.0",
-        "@jest/types": "^27.4.0",
-        "babel-jest": "^27.4.0",
+        "@jest/test-sequencer": "^27.4.2",
+        "@jest/types": "^27.4.2",
+        "babel-jest": "^27.4.2",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-circus": "^27.4.0",
-        "jest-environment-jsdom": "^27.4.0",
-        "jest-environment-node": "^27.4.0",
+        "jest-circus": "^27.4.2",
+        "jest-environment-jsdom": "^27.4.2",
+        "jest-environment-node": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "jest-jasmine2": "^27.4.0",
+        "jest-jasmine2": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-runner": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-runner": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -6072,33 +6045,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-config/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6112,18 +6058,18 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
+      "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
+        "diff-sequences": "^27.4.0",
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
       },
       "engines": {
-        "node": ">= 10.14.2"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
@@ -6184,15 +6130,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-diff/node_modules/jest-get-type": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
     "node_modules/jest-diff/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6218,16 +6155,16 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.0.tgz",
-      "integrity": "sha512-dq6r/Uf6Q7sI/gND7WyCmQ7Z13p1CSusMkHEC//+schTrhTRe+ubPO2GtejHlWV+BldH6aMAAmtlEZgBroNrNg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.2.tgz",
+      "integrity": "sha512-53V2MNyW28CTruB3lXaHNk6PkiIFuzdOC9gR3C6j8YE/ACfrPnz+slB0s17AgU1TtxNzLuHyvNlLJ+8QYw9nBg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0"
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -6291,33 +6228,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-each/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6331,18 +6241,18 @@
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.0.tgz",
-      "integrity": "sha512-fgM6g4WftTTpRA8dB5FnmS3n+PthwjTdMwl/Lcq2QlCo0I5smyD+t82bzO9tX5w6ygxbCbnP4VkSWWYdqO4j+w==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.2.tgz",
+      "integrity": "sha512-L0dV4oq4+Ll7hZ8QCGvSELn8uOr938/QKOg6o70kMHiZOpWOjAqSf7fMVAtGhG/BVSvk1GTzhGJNOWsxtH5KbQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.4.0",
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/jsdom": "^16.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2",
         "jsdom": "^16.6.0"
       },
       "engines": {
@@ -6350,17 +6260,17 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.0.tgz",
-      "integrity": "sha512-VG3jLukpPhpffd7dUiC7+usyTG8Omytg4NOjGQtv88208O2AAMwcqpOAl1/uVOhUvbiegtVztyd3ZzAQtBxifA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.2.tgz",
+      "integrity": "sha512-nzTZ5nJ+FabuZPH2YVci7SZIHpvtNRHPt8+vipLkCnAgXGjVzHm7XJWdnNqXbAkExIgiKeVEkVMNZOZE/LeiIg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.4.0",
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0"
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -6376,12 +6286,12 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.0.tgz",
-      "integrity": "sha512-xTXw1/JBJvdvTEsnTlRj9u9AAg2t23r5GHbtc5eC6AuEIRPfGWV02Y67U0p4K1KpEWLsk9Pb3b6Kfde/5a3C5A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.2.tgz",
+      "integrity": "sha512-foiyAEePORUN2eeJnOtcM1y8qW0ShEd9kTjWVL4sVaMcuCJM6gtHegvYPBRT0mpI/bs4ueThM90+Eoj2ncoNsA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -6389,8 +6299,8 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       },
@@ -6402,28 +6312,28 @@
       }
     },
     "node_modules/jest-jasmine2": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.0.tgz",
-      "integrity": "sha512-yvfWhQM/ZoxXfBZJdiKXCQxt18pOrciQUDqkT+EXtzhpKPIsbPdWCVv53NOqeWnRQR4HVhNgKK/fYD6BUXCxzA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.2.tgz",
+      "integrity": "sha512-VO/fyAJSH9u0THjbteFiL8qc93ufU+yW+bdieDc8tzTCWwlWzO53UHS5nFK1qmE8izb5Smkn+XHlVt6/l06MKQ==",
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.4.0",
+        "@jest/environment": "^27.4.2",
         "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "throat": "^6.0.1"
       },
       "engines": {
@@ -6488,33 +6398,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-jasmine2/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-jasmine2/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-jasmine2/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6528,55 +6411,28 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.0.tgz",
-      "integrity": "sha512-d7QeqzIOVQeMI6VROLPNeYagcxPCvqYD6A34Ol9D+vPzs72omGXsGbuuJrChD51zuA4ESXcLYZ81L9JHr1VYGw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz",
+      "integrity": "sha512-ml0KvFYZllzPBJWDei3mDzUhyp/M4ubKebX++fPaudpe8OsxUE+m+P6ciVLboQsrzOCWDjE20/eXew9QMx/VGw==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "pretty-format": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.0.tgz",
-      "integrity": "sha512-vBy1tEyuKiItYgV9x9ubccyadOy5xAAmDBgXk8dMppXBXG4glggrGcZvE+8l1r+te477bRcFLB/hRyGm5Tdxzw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz",
+      "integrity": "sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.4.0",
+        "jest-diff": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
+        "pretty-format": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -6631,15 +6487,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/jest-matcher-utils/node_modules/diff-sequences": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
-      "dev": true,
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/jest-matcher-utils/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6647,48 +6494,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/jest-diff": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.0.tgz",
-      "integrity": "sha512-fdXgpnyQH4LNSnYgRfHN/g413bqbPspWIAZPlXrdNISehDih1VNDtuRvlzGQJ4Go+fur1HKB2IyI25t6cWi5EA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.4.0",
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/supports-color": {
@@ -6704,18 +6509,18 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.0.tgz",
-      "integrity": "sha512-2KmfpnxFwt+5CF0YST6U1IwFomX9gx2dmcAV/ZjzF9/4tlmieExl7Ch7D36l94mIxWTXhDuPji4XOvxRBdswrQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.2.tgz",
+      "integrity": "sha512-OMRqRNd9E0DkBLZpFtZkAGYOXl6ZpoMtQJWTAREJKDOFa0M6ptB7L67tp+cszMBkvSgKOhNtQp2Vbcz3ZZKo/w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -6781,33 +6586,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6821,12 +6599,12 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.0.tgz",
-      "integrity": "sha512-hQMpGIFEjhb6rtOz4JZcZaMdQytXjm54tBif9rpXfdzbEgYZ9+JGOUNqdtu3n09KG95/zEVwRI07HAuoSV1Dxw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.2.tgz",
+      "integrity": "sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*"
       },
       "engines": {
@@ -6860,18 +6638,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.0.tgz",
-      "integrity": "sha512-XF54RYG9a9fHTlovCwC5U49TVAfCkHLoJnMhgaT2AYif4E5BechlKUAlhYE4fkbr1J5LzP7O9qfgRA5JSR8HzQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.2.tgz",
+      "integrity": "sha512-d/zqPjxCzMqHlOdRTg8cTpO9jY+1/T74KazT8Ws/LwmwxV5sRMWOkiLjmzUCDj/5IqA5XHNK4Hkmlq9Kdpb9Sg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
@@ -6881,14 +6659,14 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.0.tgz",
-      "integrity": "sha512-D+Ean4nLgbRqhWCSKJIWpC36O7itmZbVQjnHWLF4brAP0r2sGATXjjhERIaiBCt/V2IhCDcH0EvS+PA7gSrf5g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.2.tgz",
+      "integrity": "sha512-hb++cTpqvOWfU49MCP/JQkxmnrhKoAVqXWFjgYXswRSVGk8Q6bDTSvhbCeYXDtXaymY0y7WrrSIlKogClcKJuw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-snapshot": "^27.4.0"
+        "jest-snapshot": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -6965,31 +6743,31 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.0.tgz",
-      "integrity": "sha512-ncnnOVQlqDorBAMNTuA2Htg3XJlnwAySpUBDmlJy4+WEwb5zB2cDLA3roPSMe0lVn8mGGXccl1/a8xwvE6txiQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.2.tgz",
+      "integrity": "sha512-YsgbYKk8V7J5BQPINXhdzNLoqIwUWrJkV9h6/ccsn6fbmC3n3ax1K5cDWzAU9qXyaQhetwFqPpHmAHIACscRKQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.4.0",
-        "@jest/environment": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.4.0",
-        "jest-environment-jsdom": "^27.4.0",
-        "jest-environment-node": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-leak-detector": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-environment-jsdom": "^27.4.2",
+        "jest-environment-node": "^27.4.2",
+        "jest-haste-map": "^27.4.2",
+        "jest-leak-detector": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
@@ -7068,18 +6846,18 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.0.tgz",
-      "integrity": "sha512-8IcQQFhVWWNq45wuDYooIDNdmhOVebOsIDOfXN/Xbw4h/6G1qy9+i5OND7Qmb4g+cSawK5C2tAdHcdR8Q9eSew==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.2.tgz",
+      "integrity": "sha512-eqPgcBaUNaw6j8T5M+dnfAEh6MIrh2YmtskCr9sl50QYpD22Sg+QqHw3J3nmaLzVMbBtOMHFFxLF0Qx8MsZVFQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.4.0",
-        "@jest/environment": "^27.4.0",
-        "@jest/globals": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.2",
+        "@jest/globals": "^27.4.2",
         "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -7088,14 +6866,14 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-mock": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.2.0"
@@ -7188,9 +6966,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.0.tgz",
-      "integrity": "sha512-iOisfzB00tQE/rk+LzLzjbjElT4Lq26ZrYHX/1OfhVb7IZbu/2i4bkS7YK3fimfw3zleWRTleUMCmWGi+GCjpQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.2.tgz",
+      "integrity": "sha512-DI7lJlNIu6WSQ+esqhnJzEzU70+dV+cNjoF1c+j5FagWEd3KtOyZvVliAH0RWNQ6KSnAAnKSU0qxJ8UXOOhuUQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.7.2",
@@ -7199,23 +6977,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.4.0",
+        "jest-diff": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-util": "^27.4.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "semver": "^7.3.2"
       },
       "engines": {
@@ -7271,15 +7049,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/jest-snapshot/node_modules/diff-sequences": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
-      "dev": true,
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7287,48 +7056,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-diff": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.0.tgz",
-      "integrity": "sha512-fdXgpnyQH4LNSnYgRfHN/g413bqbPspWIAZPlXrdNISehDih1VNDtuRvlzGQJ4Go+fur1HKB2IyI25t6cWi5EA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.4.0",
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
@@ -7359,12 +7086,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.0.tgz",
-      "integrity": "sha512-9HL5h/IWeg2u2dt0UIiseVRCnadh7CMPD4B9AeoEO23/NofaEfcPzIfl8dw45CpGHjP+xenw1viQYMd25DWquA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+      "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -7446,17 +7173,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.0.tgz",
-      "integrity": "sha512-Gsfh/KtS7fXDNzz3oKmB1F8dFVqWwqOwhUqEHhKM8Y0R0bJK8R2HLiuqKfnqfbuybdiGiVdzqaK5c0poZaQAew==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.2.tgz",
+      "integrity": "sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.4.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.4.0"
+        "pretty-format": "^27.4.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -7532,33 +7259,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-      "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.4.0",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7572,17 +7272,17 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.0.tgz",
-      "integrity": "sha512-0ZXzsp/NArW6IXxo4g7DP/nCJqS/OLCZyl08qzd8ANGSEoTsliivBumjUK5/0gvx/K4Oc60APNyTMfJJ6WENcg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.2.tgz",
+      "integrity": "sha512-NJvMVyyBeXfDezhWzUOCOYZrUmkSCiatpjpm+nFUid74OZEHk6aMLrZAukIiFDwdbqp6mTM6Ui1w4oc+8EobQg==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -7660,9 +7360,9 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.0.tgz",
-      "integrity": "sha512-4WuKcUxtzxBoKOUFbt1MtTY9fJwPVD4aN/4Cgxee7OLetPZn5as2bjfZz98XSf2Zq1JFfhqPZpS+43BmWXKgCA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.2.tgz",
+      "integrity": "sha512-0QMy/zPovLfUPyHuOuuU4E+kGACXXE84nRnq6lBVI9GJg5DCBiA97SATi+ZP8CpiJwEQy1oCPjRBf8AnLjN+Ag==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -7723,13 +7423,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -7779,18 +7478,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/jsesc": {
@@ -7938,12 +7625,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "node_modules/loose-envify": {
@@ -8309,11 +7990,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8499,35 +8184,39 @@
       }
     },
     "node_modules/pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.5.0.tgz",
+      "integrity": "sha512-F/583dsETP+2fh9jE8rjN+sjrfP8EX2jAeZ1EyyPt+vuj4C59dhUcSDXke+8VLXxWoxUHc43MBG9eT5C2fba8A==",
       "dependencies": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
         "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "get-caller-file": "^2.0.5",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
-    "node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
-    "node_modules/pino/node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
       "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
       "version": "4.0.1",
@@ -8563,113 +8252,30 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
+        "@jest/types": "^27.4.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/pretty-format/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/pretty-format/node_modules/@types/yargs": {
-      "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/pretty-format/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pretty-format/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/progress": {
@@ -8775,6 +8381,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -8868,15 +8495,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8988,6 +8606,14 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-VFlmNrvZ44a0QnRY2yfEIUhbMh8BjTFWf2mRG/8mCEAKTfQYV8xxfn6P+00OLej0gznC5C+hfgcEF7AGrN5Stw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9089,60 +8715,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/sonic-boom": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.2.tgz",
-      "integrity": "sha512-qr2XGoMP23j85LfqOMxBEunlJ5P66hhy+3CLLTFtoLHYJuG89Qs+zUZC+d4xH1Jd4lfT7IkGaNa1z5kJt15fjA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.4.0.tgz",
+      "integrity": "sha512-2jSXeHjrovvsrnQ0tvG6eUjDdtMBxtYDAHr18mGDM/Pno/Wdw+pQ1AXUWKCZgriZ9MvCVdUEXXOUfVEwPcrieg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -9207,6 +8783,14 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9233,6 +8817,38 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -9398,44 +9014,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -9471,6 +9049,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.0.tgz",
+      "integrity": "sha512-kTMZeX4Dzlb1zZ00/01aerGaTw2i8NE4sWF0TvF1uXewRhCiUjCvatQkvxIvFqauWG2ADFS2Wpd3qBeYL9i3dg==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -9574,9 +9160,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.7.0.tgz",
+      "integrity": "sha512-gmfzrsfDuoQUpqteXPE1X8D2GdtEAhP+X9pdXj3xBbg86OO8ZtSTtJ9BVopDyWtdNuwbOXAYdluX4o/O65qebA==",
       "dev": true,
       "engines": {
         "node": ">=12.20"
@@ -9679,6 +9265,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -9880,8 +9471,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -11181,18 +10771,18 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
+        "debug": "^4.3.2",
+        "espree": "^9.0.0",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -11262,9 +10852,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -11291,6 +10881,25 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -11306,16 +10915,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.0.tgz",
-      "integrity": "sha512-2m7Xwcd1zTWtai5DCl+b0TAfoH8p5uqUoKmfzJCAfCrIwoJAf3xB+4nx3eKEGoyNfg5oavrh3gjbZ1n5z5eh4Q==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.2.tgz",
+      "integrity": "sha512-xknHThRsPB/To1FUbi6pCe43y58qFC03zfb6R7fDb/FfC7k2R3i1l+izRBJf8DI46KhYGRaF14Eo9A3qbBoixg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-message-util": "^27.4.2",
+        "jest-util": "^27.4.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -11371,35 +10980,35 @@
       }
     },
     "@jest/core": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.0.tgz",
-      "integrity": "sha512-P6eoNIbE0OeenvCxrwdj0jRgeZg8r4eXNCS2zMgAS8EADzdp03mKe7TNwCsEPr460QIYCBwJo4W8wqai3UPXOA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.2.tgz",
+      "integrity": "sha512-0mPM61tDbu8yc9CMKH9bvV+g+17VUpdWQtU1x6P1gk4AKj8iywWi8zBmEIl7pTGjUtYA92CNc/LlBfKCioBOow==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.0",
-        "@jest/reporters": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/reporters": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.4.0",
-        "jest-config": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-message-util": "^27.4.0",
+        "jest-changed-files": "^27.4.2",
+        "jest-config": "^27.4.2",
+        "jest-haste-map": "^27.4.2",
+        "jest-message-util": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-resolve-dependencies": "^27.4.0",
-        "jest-runner": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
-        "jest-watcher": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-resolve-dependencies": "^27.4.2",
+        "jest-runner": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
+        "jest-watcher": "^27.4.2",
         "micromatch": "^4.0.4",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
@@ -11458,53 +11067,53 @@
       }
     },
     "@jest/environment": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.0.tgz",
-      "integrity": "sha512-7HJ1c6lVNuxrj9PT5AD4yVDDqFt9B0lLsshxZJXShL/LOkLnBO4MoZMH3w1lXQJY3zxk3/l1yg2j7uRKpxF4yw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.2.tgz",
+      "integrity": "sha512-uSljKxh/rGlHlmhyeG4ZoVK9hOec+EPBkwTHkHKQ2EqDu5K+MaG9uJZ8o1CbRsSdZqSuhXvJCYhBWsORPPg6qw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.4.0"
+        "jest-mock": "^27.4.2"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.0.tgz",
-      "integrity": "sha512-oyMxDKlj/ThRms9eS0xFkxmUvjJ8lHsNS4gNErDRFSruTER1/OQi2L5N0sJav+/AcBoY/Pa313CpB6RgdDacGA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.2.tgz",
+      "integrity": "sha512-f/Xpzn5YQk5adtqBgvw1V6bF8Nx3hY0OIRRpCvWcfPl0EAjdqWPdhH3t/3XpiWZqtjIEHDyMKP9ajpva1l4Zmg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.4.0",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0"
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       }
     },
     "@jest/globals": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.0.tgz",
-      "integrity": "sha512-jIkd2RSV18wvOqFx5climVkwONuxqNKD8jHMvIumj8+E0qqWqymBcWymidjbxmJ3L3Zr60l0lAJGKw0BstREeQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.2.tgz",
+      "integrity": "sha512-KkfaHEttlGpXYAQTZHgrESiEPx2q/DKAFLGLFda1uGVrqc17snd3YVPhOxlXOHIzVPs+lQ/SDB2EIvxyGzb3Ew==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.0",
-        "@jest/types": "^27.4.0",
-        "expect": "^27.4.0"
+        "@jest/environment": "^27.4.2",
+        "@jest/types": "^27.4.2",
+        "expect": "^27.4.2"
       }
     },
     "@jest/reporters": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.0.tgz",
-      "integrity": "sha512-QqIdI9WBH5tBwSHZ81FEZkt3h8fvw+zdV0YQrUtdEbJEBGV/AHgRsIP23sdD/ybLfRFpjZJEyWT+7dM4mxnPYQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.2.tgz",
+      "integrity": "sha512-sp4aqmdBJtjKetEakzDPcZggPcVIF6w9QLkYBbaWDV6e/SIsHnF1S4KtIH91eEc2fp7ep6V/e1xvdfEoho1d2w==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -11516,10 +11125,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -11604,45 +11213,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.0.tgz",
-      "integrity": "sha512-/RiwMUC9pKK1E85CEflPvb4uE4Zo9JK2Iq3RbkbBoj4FkEASb/Zsqta8WGot2J1GxOk3rqdW513tfSDYQQJVpA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.2.tgz",
+      "integrity": "sha512-kr+bCrra9jfTgxHXHa2UwoQjxvQk3Am6QbpAiJ5x/50LW8llOYrxILkqY0lZRW/hu8FXesnudbql263+EW9iNA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.0.tgz",
-      "integrity": "sha512-yKu+sjFgelc5zUf0kcbbsO86qV0NIMPyYFFRaWTaEsq+j7aueX/Zev+NcX+bm7BCwCMWeK7V5AUE6HUOblylHA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.2.tgz",
+      "integrity": "sha512-HmHp5mlh9f9GyNej5yCS1JZIFfUGnP9+jEOH5zoq5EmsuZeYD+dGULqyvGDPtuzzbyAFJ6R4+z4SS0VvnFwwGQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
-        "jest-runtime": "^27.4.0"
+        "jest-haste-map": "^27.4.2",
+        "jest-runtime": "^27.4.2"
       }
     },
     "@jest/transform": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.0.tgz",
-      "integrity": "sha512-/8Cb8kEoCtXN/Co5lvv+jG0zv4Uj3ruIvffYUzxNGRGmM7qqaHtOBZ3WbH0T1Nvjya5utTA4YtwbInZVS6Zt9A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.2.tgz",
+      "integrity": "sha512-RTKcPZllfcmLfnlxBya7aypofhdz05+E6QITe55Ex0rxyerkgjmmpMlvVn11V0cP719Ps6WcDYCnDzxnnJUwKg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -11708,9 +11317,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.0.tgz",
-      "integrity": "sha512-jIsLdASXMf8GS7P7oGFGwobNse/6Ewq3GBPHoo0i6XRmja+NrUoDqJm4a1ffF2bHGleKJizxokcp1sCqSktP3g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11947,13 +11556,13 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
+      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
       "dev": true,
       "requires": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/jsdom": {
@@ -11985,41 +11594,14 @@
     "@types/node": {
       "version": "16.11.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
-      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw=="
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
+      "dev": true
     },
     "@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
-    },
-    "@types/pino": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
-      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
-      "requires": {
-        "@types/node": "*",
-        "@types/pino-pretty": "*",
-        "@types/pino-std-serializers": "*",
-        "sonic-boom": "^2.1.0"
-      }
-    },
-    "@types/pino-pretty": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
-      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/pino": "6.3"
-      }
-    },
-    "@types/pino-std-serializers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
-      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/prettier": {
       "version": "2.4.2",
@@ -12061,17 +11643,17 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/experimental-utils": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
@@ -12088,69 +11670,58 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz",
+      "integrity": "sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/typescript-estree": "5.5.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.5.0.tgz",
+      "integrity": "sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/typescript-estree": "5.5.0",
+        "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
+      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/visitor-keys": "5.5.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz",
+      "integrity": "sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
+        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/visitor-keys": "5.5.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
@@ -12167,13 +11738,13 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
+      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.5.0",
+        "eslint-visitor-keys": "^3.0.0"
       }
     },
     "abab": {
@@ -12183,9 +11754,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "dev": true
     },
     "acorn-globals": {
@@ -12196,6 +11767,14 @@
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -12281,24 +11860,15 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "asynckit": {
@@ -12313,11 +11883,11 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-code-frame": {
@@ -12403,13 +11973,13 @@
       }
     },
     "babel-jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.0.tgz",
-      "integrity": "sha512-4855S+YT4Hx0OiXFDBOWhrMj1Y9zYE7StlchuZtr1vbo1LEDBIkt8U6+7cse8jkpJSV98w3nBVDrPgol5Ab/cQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.2.tgz",
+      "integrity": "sha512-MADrjb3KBO2eyZCAc6QaJg6RT5u+6oEdDyHO5HEalnpwQ6LrhTsQF2Kj1Wnz2t6UPXIXPk18dSXXOT0wF5yTxA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
         "babel-preset-jest": "^27.4.0",
@@ -13002,9 +12572,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
+      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
       "dev": true
     },
     "dir-glob": {
@@ -13048,6 +12618,17 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "dev": true
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.5.tgz",
@@ -13065,6 +12646,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -13203,37 +12792,36 @@
       }
     },
     "eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.3.0.tgz",
+      "integrity": "sha512-aIay56Ph6RxOTC7xyr59Kt3ewX185SaGnAr8eWukoPLeriCrvGjvAubxuvaXOfsxhtwV5g0uBOsyhAom4qJdww==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
+        "@eslint/eslintrc": "^1.0.4",
+        "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
+        "eslint-scope": "^7.1.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.1.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
+        "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -13241,24 +12829,14 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13297,6 +12875,22 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+          "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         },
         "globals": {
@@ -13347,18 +12941,18 @@
       }
     },
     "eslint-config-xo": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.38.0.tgz",
-      "integrity": "sha512-G2jL+VyfkcZW8GoTmqLsExvrWssBedSoaQQ11vyhflDeT3csMdBVp0On+AVijrRuvgmkWeDwwUL5Rj0qDRHK6g==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.39.0.tgz",
+      "integrity": "sha512-QX+ZnQgzy/UtgF8dksIiIBzpYoEKmiL0CmZ8O0Gnby7rGXg8Cny1CXirmHp1zKYIpO7BuTmtWj8eUYOsGr0IGQ==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "1.0.10"
       }
     },
     "eslint-config-xo-typescript": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.38.0.tgz",
-      "integrity": "sha512-f5z0gN1r9X84PK1qav6T6YT1zW6KcAqtsMPtmqoKBLt4ACRr6tbAddtFwqkluAEH9JvHjWxuB8vu4KJFcjuzdQ==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.47.1.tgz",
+      "integrity": "sha512-BkbzIltZCWp8QLekKJKG8zJ/ZGezD8Z9FaJ+hJ5PrAVUGkIPmxXLLEHCKS3ax7oOqZLYQiG+jyKfQDIEdTQgbg==",
       "dev": true,
       "requires": {}
     },
@@ -13383,45 +12977,37 @@
       }
     },
     "eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
       "dev": true
     },
     "espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.1.0.tgz",
+      "integrity": "sha512-ZgYLvCS1wxOczBYGcQT9DDWgicXwJ4dbocr9uYN+/eresBAUuBu+O4WzB21ufQ/JqQT8gyp7hJ3z8SHii32mTQ==",
       "dev": true,
       "requires": {
-        "acorn": "^7.4.0",
+        "acorn": "^8.6.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+        "eslint-visitor-keys": "^3.1.0"
       }
     },
     "esprima": {
@@ -13500,16 +13086,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.0.tgz",
-      "integrity": "sha512-3V4Nq5E5dS7bzFfinUThG0OnOnNIDdEPC0KG1pBgB1Z7ZTDVuuyvSBTOQewi0z0vaGKWPaJ880tGI+pPm+5aCg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.2.tgz",
+      "integrity": "sha512-BjAXIDC6ZOW+WBFNg96J22D27Nq5ohn+oGcuP2rtOtcjuxNoV9McpQ60PcQWhdFOSBIQdR72e+4HdnbZTFSTyg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
         "jest-regex-util": "^27.4.0"
       },
       "dependencies": {
@@ -13538,6 +13124,17 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -13556,11 +13153,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
       "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg=="
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastify-warning": {
       "version": "0.2.0",
@@ -13623,11 +13215,6 @@
         "rimraf": "^3.0.2"
       }
     },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
-    },
     "flatted": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
@@ -13684,8 +13271,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -13735,12 +13321,12 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "requires": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       }
     },
     "globals": {
@@ -13924,8 +13510,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -14177,9 +13762,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-      "integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.0.tgz",
+      "integrity": "sha512-rgeP8yMlXeH4mfd9K/sQXZv1lvcS7xo379zntcotPDdMwkcGYwMxGHGZYo0/+YW5B/nor2YGKz2BH5ume405ow==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -14187,49 +13772,49 @@
       }
     },
     "jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.0.tgz",
-      "integrity": "sha512-54SYE6EmGRoHS+9/OCspbb7tAD2WYAvBBXmny2Zp39/QgnNIWZD4KujhAZyRXHWASTBa9/WfXM2oekNBIOFV2A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.2.tgz",
+      "integrity": "sha512-TAReynFYCfHNcrL+8Z74WPGafLFLF++bGkrpcsk6cO5G9S2VuJGhu2c44YFForMgF0GlYmtbpmeznkvZpNgTxg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.4.0",
+        "@jest/core": "^27.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.4.0"
+        "jest-cli": "^27.4.2"
       }
     },
     "jest-changed-files": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.0.tgz",
-      "integrity": "sha512-TacYni8ZumaB10L/fGRH92MbLYkn+MF2KtgHeAOcwnOzfmt+S6CDmJeslZuLOpnRUQKkV/Vr4qPAlrBTE5r67A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.2.tgz",
+      "integrity": "sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       }
     },
     "jest-circus": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.0.tgz",
-      "integrity": "sha512-WYmHSsuH82HZqOHPU1vD2AKyzUp5t/0R7jT1XJ8ga+hIGR5Ddv6PUQeMJvjnftyLC0izSm3tZaIYB+H6FfYqZA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.2.tgz",
+      "integrity": "sha512-2ePUSru1BGMyzxsMvRfu+tNb+PW60rUyMLJBfw1Nrh5zC8RoTPfF+zbE0JToU31a6ZVe4nnrNKWYRzlghAbL0A==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
@@ -14275,26 +13860,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14307,21 +13872,21 @@
       }
     },
     "jest-cli": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.0.tgz",
-      "integrity": "sha512-cTL2ORt/ha+x6KJfVp0oTAyPmHVw7IJ+lA3kmT/kNcWoCiKa+t/JlF5x+nJ0UfL3/IQLV+ysYgu8MjGM8WXH+w==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.2.tgz",
+      "integrity": "sha512-Ex2WhCj4s0XFntTKTnyLgV/CZKgQaZBYrKz02XOZ4nUjFD+26Fji/M1SgHm+2IWEIsQqoipNRx9RJH56p8d7MQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/core": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-config": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "prompts": "^2.0.1",
         "yargs": "^16.2.0"
       },
@@ -14378,32 +13943,32 @@
       }
     },
     "jest-config": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.0.tgz",
-      "integrity": "sha512-4ZDJd0HLX4snqDNOQYswMjQj7d7I2Bm8+TYIytDcRSAy7mkneQCKHBJu2NtIuzXxAoS2Sy+sjZ1UX/9L06zZCQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.2.tgz",
+      "integrity": "sha512-2vKqelsfHPnIzrPTpE9hImqxZLp5l9Vszpci19RdVB2i5OwoM+OkPExZMQb8aGrpEGXoKtlzvdqCL1GObiz8JQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.4.0",
-        "@jest/types": "^27.4.0",
-        "babel-jest": "^27.4.0",
+        "@jest/test-sequencer": "^27.4.2",
+        "@jest/types": "^27.4.2",
+        "babel-jest": "^27.4.2",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-circus": "^27.4.0",
-        "jest-environment-jsdom": "^27.4.0",
-        "jest-environment-node": "^27.4.0",
+        "jest-circus": "^27.4.2",
+        "jest-environment-jsdom": "^27.4.2",
+        "jest-environment-node": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "jest-jasmine2": "^27.4.0",
+        "jest-jasmine2": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-runner": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-runner": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -14447,26 +14012,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14479,15 +14024,15 @@
       }
     },
     "jest-diff": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
+      "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
+        "diff-sequences": "^27.4.0",
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14528,12 +14073,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
           "dev": true
         },
         "supports-color": {
@@ -14557,16 +14096,16 @@
       }
     },
     "jest-each": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.0.tgz",
-      "integrity": "sha512-dq6r/Uf6Q7sI/gND7WyCmQ7Z13p1CSusMkHEC//+schTrhTRe+ubPO2GtejHlWV+BldH6aMAAmtlEZgBroNrNg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.2.tgz",
+      "integrity": "sha512-53V2MNyW28CTruB3lXaHNk6PkiIFuzdOC9gR3C6j8YE/ACfrPnz+slB0s17AgU1TtxNzLuHyvNlLJ+8QYw9nBg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0"
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14609,26 +14148,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14641,33 +14160,33 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.0.tgz",
-      "integrity": "sha512-fgM6g4WftTTpRA8dB5FnmS3n+PthwjTdMwl/Lcq2QlCo0I5smyD+t82bzO9tX5w6ygxbCbnP4VkSWWYdqO4j+w==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.2.tgz",
+      "integrity": "sha512-L0dV4oq4+Ll7hZ8QCGvSELn8uOr938/QKOg6o70kMHiZOpWOjAqSf7fMVAtGhG/BVSvk1GTzhGJNOWsxtH5KbQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.0",
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/jsdom": "^16.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.0.tgz",
-      "integrity": "sha512-VG3jLukpPhpffd7dUiC7+usyTG8Omytg4NOjGQtv88208O2AAMwcqpOAl1/uVOhUvbiegtVztyd3ZzAQtBxifA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.2.tgz",
+      "integrity": "sha512-nzTZ5nJ+FabuZPH2YVci7SZIHpvtNRHPt8+vipLkCnAgXGjVzHm7XJWdnNqXbAkExIgiKeVEkVMNZOZE/LeiIg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.0",
-        "@jest/fake-timers": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/environment": "^27.4.2",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.4.0",
-        "jest-util": "^27.4.0"
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       }
     },
     "jest-get-type": {
@@ -14677,12 +14196,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.0.tgz",
-      "integrity": "sha512-xTXw1/JBJvdvTEsnTlRj9u9AAg2t23r5GHbtc5eC6AuEIRPfGWV02Y67U0p4K1KpEWLsk9Pb3b6Kfde/5a3C5A==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.2.tgz",
+      "integrity": "sha512-foiyAEePORUN2eeJnOtcM1y8qW0ShEd9kTjWVL4sVaMcuCJM6gtHegvYPBRT0mpI/bs4ueThM90+Eoj2ncoNsA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -14691,35 +14210,35 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.0.tgz",
-      "integrity": "sha512-yvfWhQM/ZoxXfBZJdiKXCQxt18pOrciQUDqkT+EXtzhpKPIsbPdWCVv53NOqeWnRQR4HVhNgKK/fYD6BUXCxzA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.2.tgz",
+      "integrity": "sha512-VO/fyAJSH9u0THjbteFiL8qc93ufU+yW+bdieDc8tzTCWwlWzO53UHS5nFK1qmE8izb5Smkn+XHlVt6/l06MKQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.4.0",
+        "@jest/environment": "^27.4.2",
         "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "pretty-format": "^27.4.0",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "throat": "^6.0.1"
       },
       "dependencies": {
@@ -14763,26 +14282,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14795,45 +14294,25 @@
       }
     },
     "jest-leak-detector": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.0.tgz",
-      "integrity": "sha512-d7QeqzIOVQeMI6VROLPNeYagcxPCvqYD6A34Ol9D+vPzs72omGXsGbuuJrChD51zuA4ESXcLYZ81L9JHr1VYGw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz",
+      "integrity": "sha512-ml0KvFYZllzPBJWDei3mDzUhyp/M4ubKebX++fPaudpe8OsxUE+m+P6ciVLboQsrzOCWDjE20/eXew9QMx/VGw==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "pretty-format": "^27.4.2"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.0.tgz",
-      "integrity": "sha512-vBy1tEyuKiItYgV9x9ubccyadOy5xAAmDBgXk8dMppXBXG4glggrGcZvE+8l1r+te477bRcFLB/hRyGm5Tdxzw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz",
+      "integrity": "sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.4.0",
+        "jest-diff": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.0"
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14870,49 +14349,11 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "diff-sequences": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-          "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "jest-diff": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.0.tgz",
-          "integrity": "sha512-fdXgpnyQH4LNSnYgRfHN/g413bqbPspWIAZPlXrdNISehDih1VNDtuRvlzGQJ4Go+fur1HKB2IyI25t6cWi5EA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.4.0",
-            "jest-get-type": "^27.4.0",
-            "pretty-format": "^27.4.0"
-          }
-        },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -14926,18 +14367,18 @@
       }
     },
     "jest-message-util": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.0.tgz",
-      "integrity": "sha512-2KmfpnxFwt+5CF0YST6U1IwFomX9gx2dmcAV/ZjzF9/4tlmieExl7Ch7D36l94mIxWTXhDuPji4XOvxRBdswrQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.2.tgz",
+      "integrity": "sha512-OMRqRNd9E0DkBLZpFtZkAGYOXl6ZpoMtQJWTAREJKDOFa0M6ptB7L67tp+cszMBkvSgKOhNtQp2Vbcz3ZZKo/w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -14982,26 +14423,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15014,12 +14435,12 @@
       }
     },
     "jest-mock": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.0.tgz",
-      "integrity": "sha512-hQMpGIFEjhb6rtOz4JZcZaMdQytXjm54tBif9rpXfdzbEgYZ9+JGOUNqdtu3n09KG95/zEVwRI07HAuoSV1Dxw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.2.tgz",
+      "integrity": "sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*"
       }
     },
@@ -15037,18 +14458,18 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.0.tgz",
-      "integrity": "sha512-XF54RYG9a9fHTlovCwC5U49TVAfCkHLoJnMhgaT2AYif4E5BechlKUAlhYE4fkbr1J5LzP7O9qfgRA5JSR8HzQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.2.tgz",
+      "integrity": "sha512-d/zqPjxCzMqHlOdRTg8cTpO9jY+1/T74KazT8Ws/LwmwxV5sRMWOkiLjmzUCDj/5IqA5XHNK4Hkmlq9Kdpb9Sg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
@@ -15106,42 +14527,42 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.0.tgz",
-      "integrity": "sha512-D+Ean4nLgbRqhWCSKJIWpC36O7itmZbVQjnHWLF4brAP0r2sGATXjjhERIaiBCt/V2IhCDcH0EvS+PA7gSrf5g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.2.tgz",
+      "integrity": "sha512-hb++cTpqvOWfU49MCP/JQkxmnrhKoAVqXWFjgYXswRSVGk8Q6bDTSvhbCeYXDtXaymY0y7WrrSIlKogClcKJuw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-snapshot": "^27.4.0"
+        "jest-snapshot": "^27.4.2"
       }
     },
     "jest-runner": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.0.tgz",
-      "integrity": "sha512-ncnnOVQlqDorBAMNTuA2Htg3XJlnwAySpUBDmlJy4+WEwb5zB2cDLA3roPSMe0lVn8mGGXccl1/a8xwvE6txiQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.2.tgz",
+      "integrity": "sha512-YsgbYKk8V7J5BQPINXhdzNLoqIwUWrJkV9h6/ccsn6fbmC3n3ax1K5cDWzAU9qXyaQhetwFqPpHmAHIACscRKQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.0",
-        "@jest/environment": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.4.0",
-        "jest-environment-jsdom": "^27.4.0",
-        "jest-environment-node": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-leak-detector": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-runtime": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-worker": "^27.4.0",
+        "jest-environment-jsdom": "^27.4.2",
+        "jest-environment-node": "^27.4.2",
+        "jest-haste-map": "^27.4.2",
+        "jest-leak-detector": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-runtime": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.2",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
@@ -15198,18 +14619,18 @@
       }
     },
     "jest-runtime": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.0.tgz",
-      "integrity": "sha512-8IcQQFhVWWNq45wuDYooIDNdmhOVebOsIDOfXN/Xbw4h/6G1qy9+i5OND7Qmb4g+cSawK5C2tAdHcdR8Q9eSew==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.2.tgz",
+      "integrity": "sha512-eqPgcBaUNaw6j8T5M+dnfAEh6MIrh2YmtskCr9sl50QYpD22Sg+QqHw3J3nmaLzVMbBtOMHFFxLF0Qx8MsZVFQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.0",
-        "@jest/environment": "^27.4.0",
-        "@jest/globals": "^27.4.0",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.2",
+        "@jest/globals": "^27.4.2",
         "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -15218,14 +14639,14 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-mock": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
         "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-snapshot": "^27.4.0",
-        "jest-util": "^27.4.0",
-        "jest-validate": "^27.4.0",
+        "jest-resolve": "^27.4.2",
+        "jest-snapshot": "^27.4.2",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.2.0"
@@ -15293,9 +14714,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.0.tgz",
-      "integrity": "sha512-iOisfzB00tQE/rk+LzLzjbjElT4Lq26ZrYHX/1OfhVb7IZbu/2i4bkS7YK3fimfw3zleWRTleUMCmWGi+GCjpQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.2.tgz",
+      "integrity": "sha512-DI7lJlNIu6WSQ+esqhnJzEzU70+dV+cNjoF1c+j5FagWEd3KtOyZvVliAH0RWNQ6KSnAAnKSU0qxJ8UXOOhuUQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -15304,23 +14725,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/transform": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.4.0",
+        "expect": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.4.0",
+        "jest-diff": "^27.4.2",
         "jest-get-type": "^27.4.0",
-        "jest-haste-map": "^27.4.0",
-        "jest-matcher-utils": "^27.4.0",
-        "jest-message-util": "^27.4.0",
-        "jest-resolve": "^27.4.0",
-        "jest-util": "^27.4.0",
+        "jest-haste-map": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.2",
+        "jest-util": "^27.4.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.4.0",
+        "pretty-format": "^27.4.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -15358,49 +14779,11 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "diff-sequences": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-          "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "jest-diff": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.0.tgz",
-          "integrity": "sha512-fdXgpnyQH4LNSnYgRfHN/g413bqbPspWIAZPlXrdNISehDih1VNDtuRvlzGQJ4Go+fur1HKB2IyI25t6cWi5EA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.4.0",
-            "jest-get-type": "^27.4.0",
-            "pretty-format": "^27.4.0"
-          }
-        },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
         },
         "semver": {
           "version": "7.3.5",
@@ -15423,12 +14806,12 @@
       }
     },
     "jest-util": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.0.tgz",
-      "integrity": "sha512-9HL5h/IWeg2u2dt0UIiseVRCnadh7CMPD4B9AeoEO23/NofaEfcPzIfl8dw45CpGHjP+xenw1viQYMd25DWquA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+      "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -15488,17 +14871,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.0.tgz",
-      "integrity": "sha512-Gsfh/KtS7fXDNzz3oKmB1F8dFVqWwqOwhUqEHhKM8Y0R0bJK8R2HLiuqKfnqfbuybdiGiVdzqaK5c0poZaQAew==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.2.tgz",
+      "integrity": "sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.0",
+        "@jest/types": "^27.4.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.4.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.4.0"
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15547,26 +14930,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "pretty-format": {
-          "version": "27.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz",
-          "integrity": "sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.4.0",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15579,17 +14942,17 @@
       }
     },
     "jest-watcher": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.0.tgz",
-      "integrity": "sha512-0ZXzsp/NArW6IXxo4g7DP/nCJqS/OLCZyl08qzd8ANGSEoTsliivBumjUK5/0gvx/K4Oc60APNyTMfJJ6WENcg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.2.tgz",
+      "integrity": "sha512-NJvMVyyBeXfDezhWzUOCOYZrUmkSCiatpjpm+nFUid74OZEHk6aMLrZAukIiFDwdbqp6mTM6Ui1w4oc+8EobQg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.4.0",
-        "@jest/types": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "string-length": "^4.0.1"
       },
       "dependencies": {
@@ -15645,9 +15008,9 @@
       }
     },
     "jest-worker": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.0.tgz",
-      "integrity": "sha512-4WuKcUxtzxBoKOUFbt1MtTY9fJwPVD4aN/4Cgxee7OLetPZn5as2bjfZz98XSf2Zq1JFfhqPZpS+43BmWXKgCA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.2.tgz",
+      "integrity": "sha512-0QMy/zPovLfUPyHuOuuU4E+kGACXXE84nRnq6lBVI9GJg5DCBiA97SATi+ZP8CpiJwEQy1oCPjRBf8AnLjN+Ag==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -15698,13 +15061,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsdom": {
@@ -15740,14 +15102,6 @@
         "whatwg-url": "^8.5.0",
         "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-          "dev": true
-        }
       }
     },
     "jsesc": {
@@ -15867,12 +15221,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
-    "lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "loose-envify": {
@@ -16156,11 +15504,15 @@
         "object-keys": "^1.1.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16292,34 +15644,36 @@
       "dev": true
     },
     "pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.5.0.tgz",
+      "integrity": "sha512-F/583dsETP+2fh9jE8rjN+sjrfP8EX2jAeZ1EyyPt+vuj4C59dhUcSDXke+8VLXxWoxUHc43MBG9eT5C2fba8A==",
       "requires": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
         "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "get-caller-file": "^2.0.5",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      },
-      "dependencies": {
-        "sonic-boom": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "flatstr": "^1.0.12"
-          }
-        }
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
     },
     "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
       "version": "4.0.1",
@@ -16346,87 +15700,22 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
+        "@jest/types": "^27.4.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.14",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
         "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -16502,6 +15791,21 @@
           }
         }
       }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -16582,12 +15886,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -16656,6 +15954,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-VFlmNrvZ44a0QnRY2yfEIUhbMh8BjTFWf2mRG/8mCEAKTfQYV8xxfn6P+00OLej0gznC5C+hfgcEF7AGrN5Stw=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -16740,47 +16043,10 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
     "sonic-boom": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.2.tgz",
-      "integrity": "sha512-qr2XGoMP23j85LfqOMxBEunlJ5P66hhy+3CLLTFtoLHYJuG89Qs+zUZC+d4xH1Jd4lfT7IkGaNa1z5kJt15fjA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.4.0.tgz",
+      "integrity": "sha512-2jSXeHjrovvsrnQ0tvG6eUjDdtMBxtYDAHr18mGDM/Pno/Wdw+pQ1AXUWKCZgriZ9MvCVdUEXXOUfVEwPcrieg==",
       "requires": {
         "atomic-sleep": "^1.0.0"
       }
@@ -16841,6 +16107,11 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -16861,6 +16132,26 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
+        }
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -16985,39 +16276,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
-      "dev": true,
-      "requires": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
-      }
-    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -17044,6 +16302,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.0.tgz",
+      "integrity": "sha512-kTMZeX4Dzlb1zZ00/01aerGaTw2i8NE4sWF0TvF1uXewRhCiUjCvatQkvxIvFqauWG2ADFS2Wpd3qBeYL9i3dg==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "throat": {
       "version": "6.0.1",
@@ -17123,9 +16389,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.7.0.tgz",
+      "integrity": "sha512-gmfzrsfDuoQUpqteXPE1X8D2GdtEAhP+X9pdXj3xBbg86OO8ZtSTtJ9BVopDyWtdNuwbOXAYdluX4o/O65qebA==",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -17197,6 +16463,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -17360,8 +16631,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
         "always"
       ],
       "tsdoc/syntax": "error",
-      "@typescript-eslint/naming-convention": "off"
+      "@typescript-eslint/naming-convention": "off",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -89,28 +89,27 @@
     "@babel/preset-env": "^7.13.15",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
-    "@types/jest": "^26.0.23",
+    "@types/jest": "^27.0.3",
     "@types/nock": "^11.1.0",
     "@types/simple-oauth2": "^4.1.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.5.0",
+    "@typescript-eslint/parser": "^5.5.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "dotenv": "^10.0.0",
-    "eslint": "^7.24.0",
-    "eslint-config-xo": "^0.38.0",
-    "eslint-config-xo-typescript": "^0.38.0",
+    "eslint": "^8.3.0",
+    "eslint-config-xo": "^0.39.0",
+    "eslint-config-xo-typescript": "^0.47.1",
     "eslint-plugin-tsdoc": "^0.2.14",
-    "jest": "^27.0.4",
-    "nock": "^13.0.11",
+    "jest": "^27.4.2",
+    "nock": "^13.2.1",
     "npm-run-all": "^4.1.5",
     "simple-oauth2": "^4.2.0",
-    "typescript": "^4.2.4",
-    "type-fest": "^2.3.4"
+    "type-fest": "^2.7.0",
+    "typescript": "^4.5.2"
   },
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^0.24.0",
     "jwt-decode": "^3.1.2",
-    "pino": "^6.11.3",
-    "@types/pino": "^6.3.8"
+    "pino": "^7.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "tsdoc/syntax": "error",
       "@typescript-eslint/naming-convention": "off",
       "@typescript-eslint/ban-ts-comment": "off",
-      "@typescript-eslint/no-unsafe-assignment": "off"
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "no-warning-comments": "off"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "error",
         "always"
       ],
-      "tsdoc/syntax": "error"
+      "tsdoc/syntax": "error",
+      "@typescript-eslint/naming-convention": "off"
     }
   },
   "jest": {

--- a/src/BillingPageTokenService.ts
+++ b/src/BillingPageTokenService.ts
@@ -19,8 +19,8 @@ export class BillingPageTokenService extends Base {
       {
         404: () => new SpaceNotFoundException(spaceName),
         403: () => new ForbiddenException("Token can only be acquired by space owners and admins"),
-        500: response => new InternalServerException(response?.body?.message ?? "Could not retrieve token")
-      }
+        500: response => new InternalServerException(response?.body?.message ?? "Could not retrieve token"),
+      },
     );
 
     return (token as unknown) as string;

--- a/src/CatalogAPI.ts
+++ b/src/CatalogAPI.ts
@@ -7,6 +7,7 @@ import type { MapToEntity } from "./types/types";
  *
  * @alpha
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface CatalogAPI {
   id?: string;
   url?: string;
@@ -16,4 +17,5 @@ export interface CatalogAPI {
   updatedAt?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type CatalogAPIEntity = MapToEntity<CatalogAPI>;

--- a/src/CatalogAPI.ts
+++ b/src/CatalogAPI.ts
@@ -7,7 +7,6 @@ import type { MapToEntity } from "./types/types";
  *
  * @alpha
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface CatalogAPI {
   id?: string;
   url?: string;
@@ -17,5 +16,4 @@ export interface CatalogAPI {
   updatedAt?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export type CatalogAPIEntity = MapToEntity<CatalogAPI>;

--- a/src/Exceptions.test.ts
+++ b/src/Exceptions.test.ts
@@ -5,12 +5,12 @@ import { NotFoundException, LensSDKException } from "./exceptions";
 
 export const plaform404response = {
   name: "HTTPError",
-  message: "Response code 404 (Not Found)"
+  message: "Response code 404 (Not Found)",
 };
 
 export const plaform500response = {
   name: "HTTPError",
-  message: "Response code 500 (Internal Server Error)"
+  message: "Response code 500 (Internal Server Error)",
 };
 
 describe(".users.*", () => {

--- a/src/InvitationService.ts
+++ b/src/InvitationService.ts
@@ -146,7 +146,8 @@ class InvitationService extends Base {
       async () => fetch.patch(url, invitation),
       {
         403: error => {
-          if (error?.body?.message?.includes("your email address domain")) {
+          const message = error?.body?.message;
+          if (typeof message === "string" && message.includes("your email address domain")) {
             return new InvalidEmailDomainException(error?.body?.message);
           }
 

--- a/src/InvitationService.ts
+++ b/src/InvitationService.ts
@@ -10,7 +10,7 @@ import {
   BadRequestException,
   ForbiddenException,
   InvalidEmailDomainException,
-  NotFoundException
+  NotFoundException,
 } from "./exceptions";
 import { Except } from "type-fest";
 import type { MapToEntity } from "./types/types";
@@ -65,8 +65,8 @@ class InvitationService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        404: () => new NotFoundException()
-      }
+        404: () => new NotFoundException(),
+      },
     );
 
     return (json as unknown) as Invitation;
@@ -82,8 +82,8 @@ class InvitationService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        404: () => new NotFoundException()
-      }
+        404: () => new NotFoundException(),
+      },
     );
 
     return (json as unknown) as Invitation;
@@ -128,8 +128,8 @@ class InvitationService extends Base {
 
           return new PastExpiryException();
         },
-        400: () => new BadRequestException("Invalid invitation kind")
-      }
+        400: () => new BadRequestException("Invalid invitation kind"),
+      },
     );
 
     return json as Invitation & { weblink?: string };
@@ -151,8 +151,8 @@ class InvitationService extends Base {
           }
 
           return new ForbiddenException(error?.body?.message);
-        }
-      }
+        },
+      },
     );
 
     return (json as unknown) as Invitation;

--- a/src/LensPlatformClient.test.ts
+++ b/src/LensPlatformClient.test.ts
@@ -8,7 +8,7 @@ export const minimumOptions = {
   accessToken, // The access token for apis
   keyCloakAddress: "", // Keycloak address, e.g. "https://keycloak.k8slens.dev"
   keycloakRealm: "", // The realm name, e.g. "lensCloud"
-  apiEndpointAddress // Api endpoint address, e.g. "https://api.k8slens.dev"
+  apiEndpointAddress, // Api endpoint address, e.g. "https://api.k8slens.dev"
 };
 
 describe("LensPlatformClient", () => {
@@ -26,20 +26,20 @@ describe("LensPlatformClient", () => {
     // @ts-expect-error
     expect(() => new LensPlatformClient({
       accessToken: undefined,
-      getAccessToken: undefined
+      getAccessToken: undefined,
     })).toThrow("Both accessToken undefined or getAccessToken are undefined");
   });
 
   it("can `new LensPlatformClient` with minimum (but valid) options", () => {
     expect(
-      () => new LensPlatformClient(minimumOptions)
+      () => new LensPlatformClient(minimumOptions),
     ).not.toThrow();
   });
 
   it(".authHeader", () => {
     const lensPlatformClient = new LensPlatformClient(minimumOptions);
     expect(lensPlatformClient.authHeader).toEqual({
-      Authorization: `Bearer ${accessToken}`
+      Authorization: `Bearer ${accessToken}`,
     });
   });
 
@@ -47,13 +47,13 @@ describe("LensPlatformClient", () => {
     it(("adds Authorization header"), async () => {
       const expectedHeaders = { Authorization: `Bearer ${accessToken}` };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "get"),
         jest.spyOn(axios, "head"),
-        jest.spyOn(axios, "delete")
+        jest.spyOn(axios, "delete"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -62,7 +62,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.get(apiEndpointAddress),
           _fetch.head(apiEndpointAddress),
-          _fetch.delete(apiEndpointAddress)
+          _fetch.delete(apiEndpointAddress),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -78,7 +78,7 @@ describe("LensPlatformClient", () => {
       const lensPlatformClient = new LensPlatformClient({
         ...minimumOptions,
         accessToken: "",
-        getAccessToken: async () => Promise.resolve("")
+        getAccessToken: async () => Promise.resolve(""),
       });
 
       const spy = jest.spyOn(axios, "get");
@@ -97,13 +97,13 @@ describe("LensPlatformClient", () => {
     it(("adds Authorization header with body"), async () => {
       const expectedHeaders = { Authorization: `Bearer ${accessToken}` };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "post"),
         jest.spyOn(axios, "put"),
-        jest.spyOn(axios, "patch")
+        jest.spyOn(axios, "patch"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -112,7 +112,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.post(apiEndpointAddress),
           _fetch.put(apiEndpointAddress),
-          _fetch.patch(apiEndpointAddress)
+          _fetch.patch(apiEndpointAddress),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -128,13 +128,13 @@ describe("LensPlatformClient", () => {
       const extraOptions = { withCredentials: true };
       const expectedHeaders = { Authorization: `Bearer ${accessToken}` };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "get"),
         jest.spyOn(axios, "head"),
-        jest.spyOn(axios, "delete")
+        jest.spyOn(axios, "delete"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -142,7 +142,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.get(apiEndpointAddress, extraOptions),
           _fetch.head(apiEndpointAddress, extraOptions),
-          _fetch.delete(apiEndpointAddress, extraOptions)
+          _fetch.delete(apiEndpointAddress, extraOptions),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -158,13 +158,13 @@ describe("LensPlatformClient", () => {
       const extraOptions = { withCredentials: true };
       const expectedHeaders = { Authorization: `Bearer ${accessToken}` };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "post"),
         jest.spyOn(axios, "put"),
-        jest.spyOn(axios, "patch")
+        jest.spyOn(axios, "patch"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -172,7 +172,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.post(apiEndpointAddress, undefined, extraOptions),
           _fetch.put(apiEndpointAddress, undefined, extraOptions),
-          _fetch.patch(apiEndpointAddress, undefined, extraOptions)
+          _fetch.patch(apiEndpointAddress, undefined, extraOptions),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -191,14 +191,14 @@ describe("LensPlatformClient", () => {
       const lensPlatformClient = new LensPlatformClient({
         ...minimumOptions,
         ...{
-          defaultHeaders: { "X-Consumer-Id": "xx-yy-zz" }
-        }
+          defaultHeaders: { "X-Consumer-Id": "xx-yy-zz" },
+        },
       });
 
       const spies = [
         jest.spyOn(axios, "get"),
         jest.spyOn(axios, "head"),
-        jest.spyOn(axios, "delete")
+        jest.spyOn(axios, "delete"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -207,7 +207,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.get(apiEndpointAddress, { headers: extraHeader }),
           _fetch.head(apiEndpointAddress, { headers: extraHeader }),
-          _fetch.delete(apiEndpointAddress, { headers: extraHeader })
+          _fetch.delete(apiEndpointAddress, { headers: extraHeader }),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -226,14 +226,14 @@ describe("LensPlatformClient", () => {
       const lensPlatformClient = new LensPlatformClient({
         ...minimumOptions,
         ...{
-          defaultHeaders: { "X-Consumer-Id": "xx-yy-zz" }
-        }
+          defaultHeaders: { "X-Consumer-Id": "xx-yy-zz" },
+        },
       });
 
       const spies = [
         jest.spyOn(axios, "post"),
         jest.spyOn(axios, "put"),
-        jest.spyOn(axios, "patch")
+        jest.spyOn(axios, "patch"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -242,7 +242,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.post(apiEndpointAddress, {}, { headers: extraHeader }),
           _fetch.put(apiEndpointAddress, {}, { headers: extraHeader }),
-          _fetch.patch(apiEndpointAddress, {}, { headers: extraHeader })
+          _fetch.patch(apiEndpointAddress, {}, { headers: extraHeader }),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -258,13 +258,13 @@ describe("LensPlatformClient", () => {
       const extraHeader = { "X-An-Example": "Header" };
       const extraOption = { json: { an: "example_extra_option" } };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "get"),
         jest.spyOn(axios, "head"),
-        jest.spyOn(axios, "delete")
+        jest.spyOn(axios, "delete"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -273,7 +273,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.get(apiEndpointAddress, { ...extraOption, headers: extraHeader }),
           _fetch.head(apiEndpointAddress, { ...extraOption, headers: extraHeader }),
-          _fetch.delete(apiEndpointAddress, { ...extraOption, headers: extraHeader })
+          _fetch.delete(apiEndpointAddress, { ...extraOption, headers: extraHeader }),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -282,9 +282,9 @@ describe("LensPlatformClient", () => {
           expect(spy).toBeCalledWith(apiEndpointAddress, {
             headers: {
               ...extraHeader,
-              ...{ Authorization: `Bearer ${accessToken}` }
+              ...{ Authorization: `Bearer ${accessToken}` },
             },
-            ...extraOption
+            ...extraOption,
           });
           spy.mockRestore();
         });
@@ -295,13 +295,13 @@ describe("LensPlatformClient", () => {
       const extraHeader = { "X-An-Example": "Header" };
       const extraOption = { json: { an: "example_extra_option" } };
       const lensPlatformClient = new LensPlatformClient({
-        ...minimumOptions
+        ...minimumOptions,
       });
 
       const spies = [
         jest.spyOn(axios, "post"),
         jest.spyOn(axios, "put"),
-        jest.spyOn(axios, "patch")
+        jest.spyOn(axios, "patch"),
       ];
 
       const _fetch = lensPlatformClient.fetch;
@@ -310,7 +310,7 @@ describe("LensPlatformClient", () => {
         await Promise.all([
           _fetch.post(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader }),
           _fetch.put(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader }),
-          _fetch.patch(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader })
+          _fetch.patch(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader }),
         ]);
       } catch (e: unknown) {
         // Do not handle exceptions
@@ -319,9 +319,9 @@ describe("LensPlatformClient", () => {
           expect(spy).toBeCalledWith(apiEndpointAddress, { a: 1 }, {
             headers: {
               ...extraHeader,
-              ...{ Authorization: `Bearer ${accessToken}` }
+              ...{ Authorization: `Bearer ${accessToken}` },
             },
-            ...extraOption
+            ...extraOption,
           });
           spy.mockRestore();
         });

--- a/src/LensPlatformClient.test.ts
+++ b/src/LensPlatformClient.test.ts
@@ -16,7 +16,7 @@ describe("LensPlatformClient", () => {
 
   it("is a class", () => {
     // @ts-expect-error
-    // eslint-disable-next-line new-cap
+    // eslint-disable-next-line new-cap, @typescript-eslint/no-unsafe-return
     expect(() => LensPlatformClient()).toThrow("Cannot call a class as a function");
   });
 
@@ -64,7 +64,7 @@ describe("LensPlatformClient", () => {
           _fetch.head(apiEndpointAddress),
           _fetch.delete(apiEndpointAddress),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -86,7 +86,7 @@ describe("LensPlatformClient", () => {
 
       try {
         await _fetch.get(apiEndpointAddress);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         expect(spy).toBeCalledWith(apiEndpointAddress, { headers: {} });
@@ -114,7 +114,7 @@ describe("LensPlatformClient", () => {
           _fetch.put(apiEndpointAddress),
           _fetch.patch(apiEndpointAddress),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -144,7 +144,7 @@ describe("LensPlatformClient", () => {
           _fetch.head(apiEndpointAddress, extraOptions),
           _fetch.delete(apiEndpointAddress, extraOptions),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -174,7 +174,7 @@ describe("LensPlatformClient", () => {
           _fetch.put(apiEndpointAddress, undefined, extraOptions),
           _fetch.patch(apiEndpointAddress, undefined, extraOptions),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -209,7 +209,7 @@ describe("LensPlatformClient", () => {
           _fetch.head(apiEndpointAddress, { headers: extraHeader }),
           _fetch.delete(apiEndpointAddress, { headers: extraHeader }),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -244,7 +244,7 @@ describe("LensPlatformClient", () => {
           _fetch.put(apiEndpointAddress, {}, { headers: extraHeader }),
           _fetch.patch(apiEndpointAddress, {}, { headers: extraHeader }),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -275,7 +275,7 @@ describe("LensPlatformClient", () => {
           _fetch.head(apiEndpointAddress, { ...extraOption, headers: extraHeader }),
           _fetch.delete(apiEndpointAddress, { ...extraOption, headers: extraHeader }),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {
@@ -312,7 +312,7 @@ describe("LensPlatformClient", () => {
           _fetch.put(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader }),
           _fetch.patch(apiEndpointAddress, { a: 1 }, { ...extraOption, headers: extraHeader }),
         ]);
-      } catch (e: unknown) {
+      } catch {
         // Do not handle exceptions
       } finally {
         spies.forEach(spy => {

--- a/src/LensPlatformClient.ts
+++ b/src/LensPlatformClient.ts
@@ -13,7 +13,7 @@ import decode from "jwt-decode";
 // Axios defaults to xhr adapter if XMLHttpRequest is available.
 // LensPlatformClient supports using the http adapter if httpAdapter
 // option is set to true
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const axiosHttpAdapter = require("axios/lib/adapters/http");
 
 export interface LensPlatformClientOptions {
@@ -205,7 +205,7 @@ class LensPlatformClient {
               const response = await (hasBody ? prop(url, requestBody, requestOptions) : prop(url, requestOptions));
 
               // Body as JavaScript plain object
-              const body = response.data;
+              const body: unknown = response.data;
 
               // Print HTTP response info in developer console
               logger.debug(`${key?.toUpperCase()} ${(response)?.status} ${(response)?.statusText} ${url} `);

--- a/src/LensPlatformClient.ts
+++ b/src/LensPlatformClient.ts
@@ -63,7 +63,7 @@ const requestLibraryMethods: KeyOfRequestLibrary[] = ["get", "post", "put", "pat
  * Function to determine if func is a function of the request library for making a request
  */
 const isRequestLibraryFunction = (
-  func: any, key: KeyOfRequestLibrary
+  func: any, key: KeyOfRequestLibrary,
 ): func is (RequestLibrary)["get"] |
 (RequestLibrary)["post"] |
 (RequestLibrary)["put"] |
@@ -141,7 +141,7 @@ class LensPlatformClient {
 
   get authHeader(): Record<string, string> {
     return {
-      Authorization: `Bearer ${this.accessToken}`
+      Authorization: `Bearer ${this.accessToken}`,
     };
   }
 
@@ -191,14 +191,14 @@ class LensPlatformClient {
               const requestHeaders: RequestHeaders = {
                 ...(token ? { Authorization: `Bearer ${token}` } : {}),
                 ...headers,
-                ...defaultHeaders
+                ...defaultHeaders,
               };
 
               const requestOptions = {
                 headers: requestHeaders,
                 ...(httpAdapter ? { adapter: axiosHttpAdapter } : {}),
                 // Merge options
-                ...restOptions
+                ...restOptions,
               };
 
               logger.debug(`request arguments ${JSON.stringify(requestOptions)}`);
@@ -222,7 +222,7 @@ class LensPlatformClient {
         }
 
         return prop;
-      }
+      },
     });
 
     return proxy;

--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -5,27 +5,27 @@ import { TeamActions } from "./Permissions";
 
 // Current user (Owner)
 const mockUser1: User = {
-  id: "1234567890"
+  id: "1234567890",
 };
 
 // Admin user
 const mockUser2: User = {
-  id: "1"
+  id: "1",
 };
 
 // Member user
 const mockUser3: User = {
-  id: "2"
+  id: "2",
 };
 
 // Random user
 const mockUser4: User = {
-  id: "3"
+  id: "3",
 };
 
 // Member of Space, but not team
 const mockUser5: User = {
-  id: "4"
+  id: "4",
 };
 
 const mockTeam1: Team = {
@@ -34,7 +34,7 @@ const mockTeam1: Team = {
   name: "mt1",
   description: "mt1",
   users: [mockUser1],
-  spaceId: "ms1"
+  spaceId: "ms1",
 };
 const mockTeam2: Team = {
   kind: "Admin",
@@ -42,7 +42,7 @@ const mockTeam2: Team = {
   name: "mt2",
   description: "mt2",
   users: [mockUser2],
-  spaceId: "ms1"
+  spaceId: "ms1",
 };
 const mockTeam3: Team = {
   kind: "Normal",
@@ -50,7 +50,7 @@ const mockTeam3: Team = {
   name: "mt3",
   description: "mt3",
   users: [mockUser3],
-  spaceId: "ms1"
+  spaceId: "ms1",
 };
 const mockSpace1: Space = {
   id: "ms1",
@@ -59,13 +59,13 @@ const mockSpace1: Space = {
   kind: "Team",
   users: [mockUser1, mockUser2, mockUser3, mockUser5],
   teams: [mockTeam1, mockTeam2, mockTeam3],
-  createdById: mockUser1.id
+  createdById: mockUser1.id,
 };
 const mockK8sCluster1: K8sCluster = {
   id: "mk1",
   createdById: mockUser3.id,
   name: "",
-  kind: "K8sCluster"
+  kind: "K8sCluster",
 };
 
 const invitationToBeRevokedByMockUser3 = "invitation_id_to_be_revoked_by_user_3";
@@ -117,14 +117,14 @@ describe("PermissionsService", () => {
     it("can't delete Personal Space", () => {
       expect(client.permission.canSpace(Actions.DeleteSpace, {
         ...mockSpace1,
-        kind: "Personal"
+        kind: "Personal",
       }, mockUser1.id!)).toBeFalsy();
     });
 
     it("can't rename Personal Space", () => {
       expect(client.permission.canSpace(Actions.RenameSpace, {
         ...mockSpace1,
-        kind: "Personal"
+        kind: "Personal",
       }, mockUser1.id!)).toBeFalsy();
     });
 
@@ -156,7 +156,7 @@ describe("PermissionsService", () => {
       expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.RevokeInvitation, mockSpace1, mockUser3.id!, {
         invitationId: invitationToBeRevokedByMockUser3,
-        invitationIdsCreatedByUserId: invitationIdsCreatedByMockUser3
+        invitationIdsCreatedByUserId: invitationIdsCreatedByMockUser3,
       })).toBeTruthy();
       expect(client.permission.canSpace(Actions.PatchSpace, mockSpace1, mockUser3.id!)).toBeFalsy();
       expect(client.permission.canSpace(Actions.AddInvitationDomain, mockSpace1, mockUser3.id!)).toBeFalsy();
@@ -190,7 +190,7 @@ describe("PermissionsService", () => {
       it("can add user to Owner team of Personal Space", () => {
         expect(client.permission.canTeam(TeamActions.AddUser, {
           ...mockSpace1,
-          kind: "Personal"
+          kind: "Personal",
         }, mockTeam1, mockUser2.id ?? "")).toBeFalsy();
       });
     });
@@ -203,7 +203,7 @@ describe("PermissionsService", () => {
       it("can't remove itself from Owner team of Personal Space", () => {
         expect(client.permission.canTeam(TeamActions.RemoveUser, {
           ...mockSpace1,
-          kind: "Personal"
+          kind: "Personal",
         }, mockTeam1, mockUser1.id ?? "", mockUser1.id ?? "")).toBeFalsy();
       });
     });
@@ -212,25 +212,25 @@ describe("PermissionsService", () => {
   describe(".canK8sCluster", () => {
     it("user can delete cluster created by the user", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser3.id!)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser3.id!),
       ).toBeTruthy();
     });
 
     it("Admin can delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser2.id!)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser2.id!),
       ).toBeTruthy();
     });
 
     it("Owner can delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser1.id!)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser1.id!),
       ).toBeTruthy();
     });
 
     it("non-owner user can't delete", () => {
       expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id!)
+        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id!),
       ).toBeFalsy();
     });
   });

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -6,7 +6,7 @@ export enum Roles {
   Admin = "Admin",
   Owner = "Owner",
   Member = "Member",
-  None = "None"
+  None = "None",
 }
 
 /**
@@ -25,16 +25,16 @@ export enum Actions {
   DeleteTeam,
   PatchTeam,
   GetBillingPageToken,
-  ChangeSpacePlan
+  ChangeSpacePlan,
 }
 
 export enum K8sClusterActions {
-  DeleteK8sCluster
+  DeleteK8sCluster,
 }
 
 export enum TeamActions {
   AddUser,
-  RemoveUser
+  RemoveUser,
 }
 
 type RevokeInvitation = {
@@ -56,7 +56,7 @@ export class Permissions {
     action: Actions,
     forSpace: Space | SpaceEntity,
     forUserId: string,
-    forRevokeInvitation?: RevokeInvitation
+    forRevokeInvitation?: RevokeInvitation,
   ) {
     const role = this.getRole(forSpace, forUserId);
     const isAdminOrOwner = [Roles.Owner, Roles.Admin].includes(role);
@@ -261,7 +261,7 @@ export class Permissions {
       && forRevokeInvitation?.invitationIdsCreatedByUserId?.length > 0
       // If invitation to revoke was created by userId
       && forRevokeInvitation?.invitationIdsCreatedByUserId.find(
-        invitationIdCreatedByUserId => invitationIdCreatedByUserId === forRevokeInvitation?.invitationId
+        invitationIdCreatedByUserId => invitationIdCreatedByUserId === forRevokeInvitation?.invitationId,
       )
     ) {
       return true;

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -5,7 +5,7 @@ import { minimumOptions as options, apiEndpointAddress } from "./LensPlatformCli
 describe(".space.*", () => {
   const spaceName = "spaceName";
   const response = {
-    name: spaceName
+    name: spaceName,
   };
   nock(apiEndpointAddress).get(/spaces/).twice().reply(200, response);
   nock(apiEndpointAddress).post("/spaces").reply(200, response);
@@ -19,7 +19,7 @@ describe(".space.*", () => {
     "getOne",
     "getMany",
     "updateOne",
-    "deleteOne"
+    "deleteOne",
   ].forEach(method => {
     it(`${method}()`, async () => {
       if (method === "deleteOne") {

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -28,6 +28,7 @@ describe(".space.*", () => {
         expect(await lensPlatformClient.space[method](spaceName, { name: spaceName })).toEqual(response);
       } else {
         // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         expect(await lensPlatformClient.space[method]({ name: spaceName })).toEqual(response);
       }
     });

--- a/src/SpaceService.ts
+++ b/src/SpaceService.ts
@@ -18,7 +18,7 @@ import {
   UserNameNotFoundException,
   NotFoundException,
   UnauthorizedException,
-  ClusterNotFoundException
+  ClusterNotFoundException,
 } from "./exceptions";
 import type { MapToEntity } from "./types/types";
 import type { Except } from "type-fest";
@@ -81,8 +81,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        404: () => new SpaceNotFoundException(name)
-      }
+        404: () => new SpaceNotFoundException(name),
+      },
     );
 
     return (json as unknown) as Space;
@@ -96,7 +96,7 @@ class SpaceService extends Base {
     const url = `${apiEndpointAddress}/spaces${queryString ? `/?${queryString}` : ""}`;
 
     const json = await throwExpected(
-      async () => fetch.get(url)
+      async () => fetch.get(url),
     );
 
     return (json as unknown) as Space[];
@@ -112,8 +112,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.post(url, space),
       {
-        422: () => new SpaceNameReservedException(space.name)
-      }
+        422: () => new SpaceNameReservedException(space.name),
+      },
     );
 
     return (json as unknown) as Space;
@@ -129,8 +129,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.post(url),
       {
-        404: () => new SpaceNotFoundException(spaceName)
-      }
+        404: () => new SpaceNotFoundException(spaceName),
+      },
     );
 
     return (json as unknown) as CatalogAPI;
@@ -148,8 +148,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.post(url, { feature, users }),
       {
-        404: () => new NotFoundException()
-      }
+        404: () => new NotFoundException(),
+      },
     );
 
     return (json as unknown) as Record<string, unknown>;
@@ -167,8 +167,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.delete(url, { data: { feature, users } }),
       {
-        404: () => new NotFoundException()
-      }
+        404: () => new NotFoundException(),
+      },
     );
 
     return (json as unknown) as Record<string, unknown>;
@@ -185,8 +185,8 @@ class SpaceService extends Base {
       async () => fetch.patch(url, space),
       {
         500: () => new TokenNotFoundException(),
-        422: () => new SpaceNameReservedException(space.name)
-      }
+        422: () => new SpaceNameReservedException(space.name),
+      },
     );
 
     return (json as unknown) as Space;
@@ -203,8 +203,8 @@ class SpaceService extends Base {
       async () => fetch.delete(url),
       {
         500: () => new TokenNotFoundException(),
-        404: () => new SpaceNotFoundException(name)
-      }
+        404: () => new SpaceNotFoundException(name),
+      },
     );
   }
 
@@ -213,7 +213,7 @@ class SpaceService extends Base {
    */
   async getBoredSecret({
     name,
-    clusterId
+    clusterId,
   }: { name: string; clusterId: string }): Promise<{ token: string }> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/spaces/${name}/k8sclusters/${clusterId}/bored-secret`;
@@ -223,8 +223,8 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space cluster and secret not being found
         404: () => new SpaceNotFoundException(name),
-        400: () => new BadRequestException("Invalid cluster")
-      }
+        400: () => new BadRequestException("Invalid cluster"),
+      },
     );
 
     return (json as unknown) as { token: string };
@@ -235,7 +235,7 @@ class SpaceService extends Base {
    */
   async getClusterToken({
     name,
-    clusterId
+    clusterId,
   }: { name: string; clusterId: string }): Promise<{ token: string }> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/spaces/${name}/k8sclusters/${clusterId}/token`;
@@ -246,8 +246,8 @@ class SpaceService extends Base {
         400: () => new BadRequestException(),
         // TODO: differentiate between space, cluster, user and token not being found
         404: error => error?.body.message.includes("Space ")
-          ? new SpaceNotFoundException(name) : new ClusterNotFoundException(clusterId)
-      }
+          ? new SpaceNotFoundException(name) : new ClusterNotFoundException(clusterId),
+      },
     );
 
     return (json as unknown) as { token: string };
@@ -262,7 +262,7 @@ class SpaceService extends Base {
 
     const json = await throwExpected(
       async () => fetch.get(url),
-      { 404: () => new SpaceNotFoundException(name) }
+      { 404: () => new SpaceNotFoundException(name) },
     );
 
     return (json as unknown) as K8sCluster[];
@@ -278,8 +278,8 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        404: () => new SpaceNotFoundException(name)
-      }
+        404: () => new SpaceNotFoundException(name),
+      },
     );
 
     return (json as unknown) as InvitationDomain[];
@@ -294,12 +294,12 @@ class SpaceService extends Base {
 
     const json = await throwExpected(
       async () => fetch.post(url, {
-        domain
+        domain,
       }),
       {
         400: () => new BadRequestException(),
-        404: () => new SpaceNotFoundException(name)
-      }
+        404: () => new SpaceNotFoundException(name),
+      },
     );
 
     return (json as unknown) as InvitationDomain;
@@ -316,8 +316,8 @@ class SpaceService extends Base {
       async () => fetch.delete(url),
       {
         // Space or InvitationDomain missing
-        404: () => new NotFoundException()
-      }
+        404: () => new NotFoundException(),
+      },
     );
   }
 
@@ -332,8 +332,8 @@ class SpaceService extends Base {
       async () => fetch.get(url),
       {
         404: error => error?.body.message.includes("Space ")
-          ? new SpaceNotFoundException(name) : new ClusterNotFoundException(clusterId)
-      }
+          ? new SpaceNotFoundException(name) : new ClusterNotFoundException(clusterId),
+      },
     );
 
     return (json as unknown) as K8sCluster;
@@ -351,8 +351,8 @@ class SpaceService extends Base {
       {
         404: () => new SpaceNotFoundException(name),
         422: () => new SpaceHasTooManyClustersException(name),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid")
-      }
+        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
+      },
     );
 
     return (json as unknown) as K8sCluster;
@@ -370,8 +370,8 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space and cluster not being found
         404: () => new SpaceNotFoundException(cluster.space?.name ?? "undefined"),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid")
-      }
+        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
+      },
     );
 
     return (json as unknown) as K8sCluster;
@@ -389,8 +389,8 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space and cluster not being found
         404: () => new SpaceNotFoundException(cluster.space?.name ?? "undefined"),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid")
-      }
+        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
+      },
     );
 
     return (json as unknown) as K8sCluster;
@@ -408,8 +408,8 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space and cluster not being found,
         // improve error handling here overall
-        404: () => new SpaceNotFoundException(name)
-      }
+        404: () => new SpaceNotFoundException(name),
+      },
     );
   }
 
@@ -427,8 +427,8 @@ class SpaceService extends Base {
         404: error => error?.body.message.includes(name)
           ? new SpaceNotFoundException(name)
           : new UserNameNotFoundException(username),
-        422: () => new CantRemoveOwnerFromSpaceException(username)
-      }
+        422: () => new CantRemoveOwnerFromSpaceException(username),
+      },
     );
   }
 
@@ -440,7 +440,7 @@ class SpaceService extends Base {
     const url = `${apiEndpointAddress}/spaces/${name}/plan`;
 
     const json = await throwExpected(
-      async () => fetch.get(url)
+      async () => fetch.get(url),
     );
 
     return (json as unknown) as BillingPlan;

--- a/src/TeamService.ts
+++ b/src/TeamService.ts
@@ -1,7 +1,7 @@
 import type { Except } from "type-fest";
 import { Base } from "./Base";
 import {
-  CantRemoveLastTeamUser, ForbiddenException, SpaceNotFoundException, throwExpected, UserNameNotFoundException
+  CantRemoveLastTeamUser, ForbiddenException, SpaceNotFoundException, throwExpected, UserNameNotFoundException,
 } from "./exceptions";
 import type { Space, SpaceEntity } from "./SpaceService";
 import type { MapToEntity } from "./types/types";
@@ -115,7 +115,7 @@ class TeamService extends Base {
           error?.body.message?.includes("Space not found")
             ? new SpaceNotFoundException()
             : new UserNameNotFoundException(username),
-        422: () => new CantRemoveLastTeamUser()
+        422: () => new CantRemoveLastTeamUser(),
       });
 
     return (json as unknown) as Team;

--- a/src/TeamService.ts
+++ b/src/TeamService.ts
@@ -1,7 +1,7 @@
 import type { Except } from "type-fest";
 import { Base } from "./Base";
 import {
-  CantRemoveLastTeamUser, ForbiddenException, SpaceNotFoundException, throwExpected, UserNameNotFoundException,
+  CantRemoveLastTeamUser, SpaceNotFoundException, throwExpected, UserNameNotFoundException,
 } from "./exceptions";
 import type { Space, SpaceEntity } from "./SpaceService";
 import type { MapToEntity } from "./types/types";
@@ -111,10 +111,14 @@ class TeamService extends Base {
 
     const json = await throwExpected(
       async () => fetch.delete(url), {
-        404: error =>
-          error?.body.message?.includes("Space not found")
-            ? new SpaceNotFoundException()
-            : new UserNameNotFoundException(username),
+        404: error => {
+          const message = error?.body.message;
+          if (typeof message === "string" && message.includes("Space not found")) {
+            return new SpaceNotFoundException();
+          }
+
+          return new UserNameNotFoundException(username);
+        },
         422: () => new CantRemoveLastTeamUser(),
       });
 

--- a/src/User.test.ts
+++ b/src/User.test.ts
@@ -7,20 +7,20 @@ describe(".user.*", () => {
   nock(apiEndpointAddress).get("/users").reply(200, [{
     id: "test-id",
     username,
-    fullname: "test fullname"
+    fullname: "test fullname",
   }]);
   nock(apiEndpointAddress).get(`/users/${username}`).reply(200, {
     id: "test-id",
     username,
     fullname: "test fullname",
-    email: "test@example.com"
+    email: "test@example.com",
   });
   nock(apiEndpointAddress).delete(`/users/${username}`).reply(200);
   nock(apiEndpointAddress).patch(`/users/${username}`).twice().reply(200, {
     id: "test-id",
     username,
     fullname: "test fullname",
-    email: "test@example.com"
+    email: "test@example.com",
   });
 
   const lensPlatformClient = new LensPlatformClient(options);
@@ -37,7 +37,7 @@ describe(".user.*", () => {
 
   it("can call updateOne with email", async () => {
     await lensPlatformClient.user.updateOne(username, {
-      email: "new@example.com"
+      email: "new@example.com",
     });
   });
 

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -8,7 +8,7 @@ import {
   UnprocessableEntityException,
   UserNameNotFoundException,
   LensSDKException,
-  TokenNotFoundException
+  TokenNotFoundException,
 } from "./exceptions";
 
 /**
@@ -56,7 +56,7 @@ class UserService extends Base {
     const url = `${apiEndpointAddress}/users/${username}${queryString ? `?${queryString}` : ""}`;
     const json = await throwExpected(
       async () => fetch.get(url),
-      { 404: () => new NotFoundException(`User ${username} not found`) }
+      { 404: () => new NotFoundException(`User ${username} not found`) },
     );
 
     return (json as unknown) as UserWithEmail;
@@ -68,8 +68,8 @@ class UserService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        400: e => new BadRequestException(e?.body?.message)
-      }
+        400: e => new BadRequestException(e?.body?.message),
+      },
     );
 
     return (json as unknown) as User[];
@@ -86,8 +86,8 @@ class UserService extends Base {
       {
         404: () => new NotFoundException(`User ${username} not found`),
         403: () => new ForbiddenException(`Modification of user ${username} is forbidden`),
-        409: () => new UsernameAlreadyExistsException()
-      }
+        409: () => new UsernameAlreadyExistsException(),
+      },
     );
 
     return (json as unknown) as User;
@@ -124,12 +124,12 @@ class UserService extends Base {
           return new LensSDKException(
             500,
             `Unexpected exception [Lens Platform SDK]: ${error?.body.message ?? "Internal server error"}`,
-            error
+            error,
           );
         },
         404: () => new UserNameNotFoundException(username),
-        422: error => new UnprocessableEntityException(error?.body.message)
-      }
+        422: error => new UnprocessableEntityException(error?.body.message),
+      },
     );
   }
 }

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -113,17 +113,21 @@ class UserService extends Base {
       async () => fetch.delete(url),
       {
         500: error => {
-          if (error?.body.message.includes("Token")) {
-            return new TokenNotFoundException();
-          }
+          const message = error?.body.message;
 
-          if (error?.body.message.includes("User")) {
-            return new UserNameNotFoundException(username);
+          if (typeof message === "string") {
+            if (message.includes("Token")) {
+              return new TokenNotFoundException();
+            }
+
+            if (message.includes("User")) {
+              return new UserNameNotFoundException(username);
+            }
           }
 
           return new LensSDKException(
             500,
-            `Unexpected exception [Lens Platform SDK]: ${error?.body.message ?? "Internal server error"}`,
+            `Unexpected exception [Lens Platform SDK]: ${error?.body.message}`,
             error,
           );
         },

--- a/src/exceptions/common.exceptions.ts
+++ b/src/exceptions/common.exceptions.ts
@@ -9,7 +9,7 @@ export class LensSDKException extends Error implements LensPlatformExceptionData
   constructor(
     public errorCode: number | string | null,
     public message: string,
-    public rawException?: unknown
+    public rawException?: unknown,
   ) {
     super(message);
     Object.setPrototypeOf(this, LensSDKException.prototype);

--- a/src/exceptions/team.exceptions.ts
+++ b/src/exceptions/team.exceptions.ts
@@ -1,4 +1,4 @@
-import { UnprocessableEntityException, ForbiddenException } from "./common.exceptions";
+import { UnprocessableEntityException } from "./common.exceptions";
 
 export class CantRemoveLastTeamUser extends UnprocessableEntityException {
   constructor(msg = "Can't remove last user from team") {

--- a/src/exceptions/utils.ts
+++ b/src/exceptions/utils.ts
@@ -23,7 +23,7 @@ const toPlatformErrorResponse = async (response: AxiosError["response"]) => {
   if (response?.data) {
     return {
       ...response,
-      body: response?.data
+      body: response?.data,
     };
   }
 
@@ -79,7 +79,7 @@ export const throwExpected = async <T = any>(fn: () => Promise<T>, exceptionsMap
 
       if (mappedExceptionFn) {
         throw mappedExceptionFn(
-          await toPlatformErrorResponse(error?.response)
+          await toPlatformErrorResponse(error?.response),
         );
       } else if (httpStatusCode === 401) {
         throw new UnauthorizedException(error.response?.data?.message, error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import type { User, UserAttributes } from "./UserService";
 export * from "./exceptions";
 export type {
   User, UserAttributes, Space, InvitationDomain, Team, K8sCluster, Invitation, BillingPlan, OpenIdConnectUserInfo,
-  SpaceEntity, TeamEntity, K8sClusterEntity, InvitationEntity, InvitationDomainEntity, DevClusterCrdState, Phase
+  SpaceEntity, TeamEntity, K8sClusterEntity, InvitationEntity, InvitationDomainEntity, DevClusterCrdState, Phase,
 };
 export type { LensPlatformClientType, LensPlatformClientOptions };
 export { LensPlatformClient, Roles, Actions, K8sClusterActions, Permissions, TeamActions };


### PR DESCRIPTION
- Disable `@typescript-eslint/naming-convention` > will introduce breaking changes if enable this.
- Disable `@typescript-eslint/ban-ts-comment` > I think it's ok to add `@ts-expect-error`...
- Disable `@typescript-eslint/no-unsafe-assignment` > This is not easy to fix, as `any` often leaks from dependencies (e.g. `axois` uses lots of `any`).
- Disable `no-warning-comments` > Just annoying.