### PR TITLE
When 400, return whatever backend returned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "lens-platform-sdk",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",

--- a/src/InvitationService.ts
+++ b/src/InvitationService.ts
@@ -7,7 +7,6 @@ import {
   UserAlreadyExistsException,
   PendingInvitationException,
   EmailMissingException,
-  BadRequestException,
   ForbiddenException,
   InvalidEmailDomainException,
   NotFoundException,
@@ -128,7 +127,6 @@ class InvitationService extends Base {
 
           return new PastExpiryException();
         },
-        400: () => new BadRequestException("Invalid invitation kind"),
       },
     );
 

--- a/src/SpaceService.ts
+++ b/src/SpaceService.ts
@@ -12,7 +12,6 @@ import {
   SpaceNameReservedException,
   TokenNotFoundException,
   SpaceHasTooManyClustersException,
-  BadRequestException,
   CantRemoveOwnerFromSpaceException,
   UserNameNotFoundException,
   NotFoundException,
@@ -221,7 +220,6 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space cluster and secret not being found
         404: () => new SpaceNotFoundException(name),
-        400: () => new BadRequestException("Invalid cluster"),
       },
     );
 
@@ -241,7 +239,6 @@ class SpaceService extends Base {
     const json = await throwExpected(
       async () => fetch.get(url),
       {
-        400: () => new BadRequestException(),
         // TODO: differentiate between space, cluster, user and token not being found
         404: error => {
           const message = error?.body.message;
@@ -301,7 +298,6 @@ class SpaceService extends Base {
         domain,
       }),
       {
-        400: () => new BadRequestException(),
         404: () => new SpaceNotFoundException(name),
       },
     );
@@ -361,7 +357,6 @@ class SpaceService extends Base {
       {
         404: () => new SpaceNotFoundException(name),
         422: () => new SpaceHasTooManyClustersException(name),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
       },
     );
 
@@ -380,7 +375,6 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space and cluster not being found
         404: () => new SpaceNotFoundException(cluster.space?.name ?? "undefined"),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
       },
     );
 
@@ -399,7 +393,6 @@ class SpaceService extends Base {
       {
         // TODO: differentiate between space and cluster not being found
         404: () => new SpaceNotFoundException(cluster.space?.name ?? "undefined"),
-        400: () => new BadRequestException("Property 'kind' of cluster object is invalid"),
       },
     );
 

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -3,7 +3,6 @@ import {
   throwExpected,
   NotFoundException,
   ForbiddenException,
-  BadRequestException,
   UsernameAlreadyExistsException,
   UnprocessableEntityException,
   UserNameNotFoundException,
@@ -67,9 +66,6 @@ class UserService extends Base {
     const url = `${apiEndpointAddress}/users${queryString ? `?${queryString}` : ""}`;
     const json = await throwExpected(
       async () => fetch.get(url),
-      {
-        400: e => new BadRequestException(e?.body?.message),
-      },
     );
 
     return (json as unknown) as User[];

--- a/src/exceptions/utils.ts
+++ b/src/exceptions/utils.ts
@@ -1,4 +1,4 @@
-import { LensSDKException, ForbiddenException, UnauthorizedException } from "./common.exceptions";
+import { LensSDKException, ForbiddenException, UnauthorizedException, BadRequestException } from "./common.exceptions";
 import axios, { AxiosError, AxiosResponse } from "axios";
 
 const parseHTTPErrorCode = (exception: AxiosError) => {
@@ -81,6 +81,8 @@ export const throwExpected = async <T = any>(fn: () => Promise<T>, exceptionsMap
         throw mappedExceptionFn(
           await toPlatformErrorResponse(error?.response),
         );
+      } else if (httpStatusCode === 400) {
+        throw new BadRequestException(error.response?.data?.message, error);
       } else if (httpStatusCode === 401) {
         throw new UnauthorizedException(error.response?.data?.message, error);
       } else if (httpStatusCode === 403) {


### PR DESCRIPTION
As 400 messages can be in many formats, let's return whatever backend return in `body.message`, instead of hardcoded message. And also includes the original (axios) exception for easier debugging.

Closes https://github.com/lensapp/lens-platform-sdk/issues/130