### PR TITLE
Add PatchK8sCluster permission check

### DIFF
--- a/src/Permissions.test.ts
+++ b/src/Permissions.test.ts
@@ -280,82 +280,142 @@ describe("PermissionsService", () => {
   });
 
   describe(".canK8sCluster", () => {
-    it("user can delete cluster created by the user", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, memberUser.id!),
-      ).toBeTruthy();
+    describe("DeleteK8sCluster", () => {
+      it("user can delete cluster created by the user", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, memberUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("Admin can delete", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, adminUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("Owner can delete", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, ownerUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("non-owner user can't delete", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id!),
+        ).toBeFalsy();
+      });
     });
 
-    it("Admin can delete", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, adminUser.id!),
-      ).toBeTruthy();
+    describe("AccessK8sCluster", () => {
+      it("user can access non-devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockK8sCluster1, memberUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("user can access own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, memberUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("user can access own devCluster 2", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, mockUser5.id!),
+        ).toBeTruthy();
+      });
+
+      it("member can't access another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, mockUser5.id!),
+        ).toBeFalsy();
+      });
+
+      it("member can't access another user's devCluster 2", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, memberUser.id!),
+        ).toBeFalsy();
+      });
+
+      it("admin can access own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, adminUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("admin can access another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, adminUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("owner can access own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, ownerUser.id!),
+        ).toBeTruthy();
+      });
+
+      it("owner can access another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, ownerUser.id!),
+        ).toBeTruthy();
+      });
     });
 
-    it("Owner can delete", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, ownerUser.id!),
-      ).toBeTruthy();
-    });
+    describe("PatchK8sCluster", () => {
+      it("user can patch non-devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockK8sCluster1, memberUser.id!),
+        ).toBeTruthy();
+      });
 
-    it("non-owner user can't delete", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.DeleteK8sCluster, mockSpace1, mockK8sCluster1, mockUser4.id!),
-      ).toBeFalsy();
-    });
+      it("user can patch own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster1, memberUser.id!),
+        ).toBeTruthy();
+      });
 
-    it("user can access non-devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockK8sCluster1, memberUser.id!),
-      ).toBeTruthy();
-    });
+      it("user can patch own devCluster 2", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster2, mockUser5.id!),
+        ).toBeTruthy();
+      });
 
-    it("user can access own devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, memberUser.id!),
-      ).toBeTruthy();
-    });
+      it("member can't patch another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster1, mockUser5.id!),
+        ).toBeFalsy();
+      });
 
-    it("user can access own devCluster 2", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, mockUser5.id!),
-      ).toBeTruthy();
-    });
+      it("member can't patch another user's devCluster 2", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster2, memberUser.id!),
+        ).toBeFalsy();
+      });
 
-    it("member can't access another user's devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, mockUser5.id!),
-      ).toBeFalsy();
-    });
+      it("admin can patch own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster1, adminUser.id!),
+        ).toBeTruthy();
+      });
 
-    it("member can't access another user's devCluster 2", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, memberUser.id!),
-      ).toBeFalsy();
-    });
+      it("admin can patch another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster2, adminUser.id!),
+        ).toBeTruthy();
+      });
 
-    it("admin can access own devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, adminUser.id!),
-      ).toBeTruthy();
-    });
+      it("owner can patch own devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster1, ownerUser.id!),
+        ).toBeTruthy();
+      });
 
-    it("admin can access another user's devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, adminUser.id!),
-      ).toBeTruthy();
-    });
-
-    it("owner can access own devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster1, ownerUser.id!),
-      ).toBeTruthy();
-    });
-
-    it("owner can access another user's devCluster", () => {
-      expect(client.permission.canK8sCluster(
-        K8sClusterActions.AccessK8sCluster, mockSpace1, mockDevCluster2, ownerUser.id!),
-      ).toBeTruthy();
+      it("owner can patch another user's devCluster", () => {
+        expect(client.permission.canK8sCluster(
+          K8sClusterActions.PatchK8sCluster, mockSpace1, mockDevCluster2, ownerUser.id!),
+        ).toBeTruthy();
+      });
     });
   });
 });

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -32,6 +32,7 @@ export enum K8sClusterActions {
   // Check if user can access the K8sCluster assuming the Space is accessible
   AccessK8sCluster,
 
+  PatchK8sCluster,
   DeleteK8sCluster,
 }
 
@@ -196,6 +197,11 @@ export class Permissions {
       // Check if user can access the K8sCluster assuming the Space is accessible
       // DevCluster K8sClusters can only be accessed by the creator or Admin/Owner
       case K8sClusterActions.AccessK8sCluster:
+        canI = !isDevCluster(forK8sCluster) || isOwnerAdmin || forK8sCluster.createdById === forUserId;
+        break;
+      // Check if user can patch the K8sCluster assuming the Space is accessible
+      // DevCluster K8sClusters can only be patched by the creator or Admin/Owner
+      case K8sClusterActions.PatchK8sCluster:
         canI = !isDevCluster(forK8sCluster) || isOwnerAdmin || forK8sCluster.createdById === forUserId;
         break;
       // Admin, Owner or K8sCluster creator can delete it


### PR DESCRIPTION
This should be used for patch permission check instead of the access action. The business logic / authorization rules are identical.