### PR TITLE
Add company name to SubscriptionInfo

### DIFF
--- a/integration-test/UserService.test.ts
+++ b/integration-test/UserService.test.ts
@@ -224,6 +224,7 @@ describe("UserService", () => {
           trialEndsAt: null,
           trialStartedAt: null,
           companyName: "sdgfdgdfg",
+          accountCode: "f63ed988-017a-4a0f-8486-cc8cf5ec6f32",
         },
         {
           currentPeriodEndsAt: "2022-07-24T12:15:15.000Z",
@@ -234,6 +235,7 @@ describe("UserService", () => {
           trialEndsAt: null,
           trialStartedAt: null,
           companyName: "sdgfdgdfg",
+          accountCode: "f63ed988-017a-4a0f-8486-cc8cf5ec6f32",
         }];
         const userSubscriptions = await bobPlatform.client.user.getUserSubscriptions(userBob.username);
         expect(userSubscriptions).toEqual(subscriptions);
@@ -251,6 +253,7 @@ describe("UserService", () => {
           trialEndsAt: null,
           trialStartedAt: null,
           companyName: "sdgfdgdfg",
+          accountCode: "f63ed988-017a-4a0f-8486-cc8cf5ec6f32",
         };
         const userSubscription = await bobPlatform.client.user.getUserSubscription(userBob.username, subscription.id);
         expect(userSubscription).toEqual(subscription);

--- a/integration-test/UserService.test.ts
+++ b/integration-test/UserService.test.ts
@@ -223,6 +223,7 @@ describe("UserService", () => {
           planName: "Pro",
           trialEndsAt: null,
           trialStartedAt: null,
+          companyName: "sdgfdgdfg",
         },
         {
           currentPeriodEndsAt: "2022-07-24T12:15:15.000Z",
@@ -232,6 +233,7 @@ describe("UserService", () => {
           planName: "Pro",
           trialEndsAt: null,
           trialStartedAt: null,
+          companyName: "sdgfdgdfg",
         }];
         const userSubscriptions = await bobPlatform.client.user.getUserSubscriptions(userBob.username);
         expect(userSubscriptions).toEqual(subscriptions);
@@ -248,6 +250,7 @@ describe("UserService", () => {
           planName: "Pro",
           trialEndsAt: null,
           trialStartedAt: null,
+          companyName: "sdgfdgdfg",
         };
         const userSubscription = await bobPlatform.client.user.getUserSubscription(userBob.username, subscription.id);
         expect(userSubscription).toEqual(subscription);

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -68,6 +68,11 @@ export type SubscriptionInfo = {
    * Name of the company of the Recurly account
    */
   companyName?: string | null;
+
+  /**
+   * Account code of the subscription's Recurly account
+   */
+  accountCode?: string | null;
 };
 
 export type Address = {

--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -63,6 +63,11 @@ export type SubscriptionInfo = {
    * Trial end date string
    */
   trialEndsAt?: string | null;
+
+  /**
+   * Name of the company of the Recurly account
+   */
+  companyName?: string | null;
 };
 
 export type Address = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ import type { OpenIdConnectUserInfo } from "./OpenIdConnect";
 import { Actions, K8sClusterActions, Permissions, Roles, TeamActions } from "./Permissions";
 import type { Space, SpaceEntity } from "./SpaceService";
 import type { Team, TeamEntity } from "./TeamService";
-import type { User, UserWithEmail, UserAttributes } from "./UserService";
+import type { User, UserWithEmail, UserAttributes, SubscriptionInfo } from "./UserService";
 
 export * from "./exceptions";
 export type {
   User, UserWithEmail, UserAttributes, Space, InvitationDomain, Team, K8sCluster, Invitation, BillingPlan, OpenIdConnectUserInfo,
-  SpaceEntity, TeamEntity, K8sClusterEntity, InvitationEntity, InvitationDomainEntity, DevClusterCrdState, Phase,
+  SpaceEntity, TeamEntity, K8sClusterEntity, InvitationEntity, InvitationDomainEntity, DevClusterCrdState, Phase, SubscriptionInfo,
 };
 export type { LensPlatformClientType, LensPlatformClientOptions };
 export { LensPlatformClient, Roles, Actions, K8sClusterActions, Permissions, TeamActions };


### PR DESCRIPTION
We need to display company name for the subscription. This is unavailable for Lens Business ID case, so it's added to subscription info.