### PR TITLE
Check if captureStackTrace is available before calling

### DIFF
--- a/integration-test/UserService.test.ts
+++ b/integration-test/UserService.test.ts
@@ -228,8 +228,8 @@ describe("UserService", () => {
           isBusinessAccount: false,
         },
         {
-          currentPeriodEndsAt: "2022-07-24T12:15:15.000Z",
-          currentPeriodStartedAt: "2022-06-24T12:15:15.000Z",
+          currentPeriodEndsAt: "2022-08-24T12:15:15.000Z",
+          currentPeriodStartedAt: "2022-07-24T12:15:15.000Z",
           id: "6264c96770f423f8980c7d45569dc21a",
           planCode: "pro-monthly",
           planName: "Pro",

--- a/src/exceptions/common.exceptions.ts
+++ b/src/exceptions/common.exceptions.ts
@@ -13,7 +13,9 @@ export class LensSDKException extends Error implements LensPlatformExceptionData
   ) {
     super(message);
     Object.setPrototypeOf(this, LensSDKException.prototype);
-    Error.captureStackTrace(this, LensSDKException);
+    if (Error.captureStackTrace !== undefined) {
+      Error.captureStackTrace(this, LensSDKException);
+    }
   }
 }
 


### PR DESCRIPTION
The captureStackTrace is not available yet in Safari and Firefox