### PR TITLE
Pass error message for SubscriptionAlreadyExistsException

### DIFF
--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -268,7 +268,7 @@ class UserService extends Base {
 
           return new NotFoundException(`Recurly subscription ${license.subscriptionId} not found`);
         },
-        409: () => new SubscriptionAlreadyExistsException(),
+        409: error => new SubscriptionAlreadyExistsException(error?.body.message ?? `Subscription for user ${username} already exists`),
         400: error => new BadRequestException(error?.body.message),
         403: () => new ForbiddenException(`Modification of user licenses for ${username} is forbidden`),
         422: error => new UnprocessableEntityException(error?.body.message),

--- a/src/exceptions/user.exceptions.ts
+++ b/src/exceptions/user.exceptions.ts
@@ -22,8 +22,8 @@ export class UsernameAlreadyExistsException extends ConflictException {
 }
 
 export class SubscriptionAlreadyExistsException extends ConflictException {
-  constructor() {
-    super();
+  constructor(message: string) {
+    super(message);
     Object.setPrototypeOf(this, SubscriptionAlreadyExistsException.prototype);
   }
 }


### PR DESCRIPTION
We don't want the default "Conflict" message in the UI.