### PR TITLE
Business subscription activate/deactivate

### DIFF
--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -327,10 +327,11 @@ class BusinessService extends Base {
    */
   async activateBusinessUserSubscription({ businessId, recurlySubscriptionId, businessInvitationId, username }: { businessId: string; recurlySubscriptionId: string; businessInvitationId: string; username: string }): Promise<UsedSeat> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
-    const url = `${apiEndpointAddress}/business/${businessId}/subscriptions/${recurlySubscriptionId}`;
+    const url = `${apiEndpointAddress}/business/${businessId}/subscriptions`;
     const json = await throwExpected(
       async () => fetch.post(url, {
         invitationId: businessInvitationId,
+        subscriptionId: recurlySubscriptionId,
       }),
       {
         404: error => new NotFoundException(error?.body.message),

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -345,6 +345,7 @@ class BusinessService extends Base {
 
   /**
    * Deactivate user business subscription seat
+   * Request user has to be an owner of the subscription seat or Business Administrator
    */
   async deActivateBusinessUserSubscription({ businessId, businessSubscriptionId, username }: { businessId: string; businessSubscriptionId: string; username: string }): Promise<UsedSeat> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -325,13 +325,13 @@ class BusinessService extends Base {
   /**
    * Activate user business subscription seat
    */
-  async activateBusinessUserSubscription({ businessId, recurlySubscriptionId, businessInvitationId, username }: { businessId: string; recurlySubscriptionId: string; businessInvitationId: string; username: string }): Promise<UsedSeat> {
+  async activateBusinessUserSubscription({ businessId, businessSubscriptionId, businessInvitationId, username }: { businessId: string; businessSubscriptionId: string; businessInvitationId: string; username: string }): Promise<UsedSeat> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/business/${businessId}/subscriptions`;
     const json = await throwExpected(
       async () => fetch.post(url, {
         invitationId: businessInvitationId,
-        subscriptionId: recurlySubscriptionId,
+        subscriptionId: businessSubscriptionId,
       }),
       {
         404: error => new NotFoundException(error?.body.message),

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -6,7 +6,6 @@ import {
   BadRequestException,
   NotFoundException,
 } from "./exceptions";
-import { License } from "./types/types";
 
 /**
  * "Lens Business ID"

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -326,7 +326,7 @@ class BusinessService extends Base {
   /**
    * Activate user business subscription seat
    */
-  async activateBusinessUserSubscription({ businessId, recurlySubscriptionId, businessInvitationId, username }: { businessId: string; recurlySubscriptionId: string; businessInvitationId: string; username: string }): Promise<License> {
+  async activateBusinessUserSubscription({ businessId, recurlySubscriptionId, businessInvitationId, username }: { businessId: string; recurlySubscriptionId: string; businessInvitationId: string; username: string }): Promise<UsedSeat> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/business/${businessId}/subscriptions/${recurlySubscriptionId}`;
     const json = await throwExpected(
@@ -341,13 +341,13 @@ class BusinessService extends Base {
       },
     );
 
-    return (json as unknown) as License;
+    return (json as unknown) as UsedSeat;
   }
 
   /**
    * Deactivate user business subscription seat
    */
-  async deActivateBusinessUserSubscription({ businessId, businessSubscriptionId, username }: { businessId: string; businessSubscriptionId: string; username: string }): Promise<License> {
+  async deActivateBusinessUserSubscription({ businessId, businessSubscriptionId, username }: { businessId: string; businessSubscriptionId: string; username: string }): Promise<UsedSeat> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/business/${businessId}/subscriptions/${businessSubscriptionId}`;
     const json = await throwExpected(
@@ -360,7 +360,7 @@ class BusinessService extends Base {
       },
     );
 
-    return (json as unknown) as License;
+    return (json as unknown) as UsedSeat;
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/lensapp/lenscloud/issues/2025.

POST for https://github.com/lensapp/lenscloud/blob/21a9c8e2cd0af0ae7718a93bc1e27657565e3052/backend/src/modules/business/business-subscriptions.controller.ts#L64

PATCH for
https://github.com/lensapp/lenscloud/blob/21a9c8e2cd0af0ae7718a93bc1e27657565e3052/backend/src/modules/business/business-subscriptions.controller.ts#L91


We can add tests when all CRUD is done for business so we can clear the state after tests