### PR TITLE
`deactivatedAt` and `expiredAt` can be null

### DIFF
--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -88,11 +88,11 @@ export type UsedSeat = {
   /**
    * The de-activation data of user_subscriptions entity in ISO format, e.g. 2022-06-28T08:13:06.000Z
    */
-  deactivatedAt: string;
+  deactivatedAt: string | null;
   /**
    * The expiration data of user_subscriptions entity in ISO format, e.g. 2022-06-28T08:13:06.000Z
    */
-  expiredAt: string;
+  expiredAt: string | null;
   /**
    * The user that is assigned to this subscription
    */


### PR DESCRIPTION
According to https://github.com/lensapp/lenscloud/blob/main/backend/src/modules/user/user-subscription.entity.ts