### PR TITLE
activatedAt/createdAt/updatedAt are not nullable

### DIFF
--- a/src/UserService.ts
+++ b/src/UserService.ts
@@ -148,7 +148,7 @@ export type SubscriptionSeatInfo = {
   /**
    * Subscription activation date string
    */
-  activatedAt: string | null;
+  activatedAt: string;
 
   /**
    * Subscription deactivation date string
@@ -158,12 +158,12 @@ export type SubscriptionSeatInfo = {
   /**
    * Subscription creation date string
    */
-  createdAt: string | null;
+  createdAt: string;
 
   /**
    * Subscription update date string
    */
-  updatedAt: string | null;
+  updatedAt: string;
 
   /**
    * Subscription expiration date string


### PR DESCRIPTION
See https://github.com/lensapp/lenscloud/blob/main/backend/src/modules/user/user-subscription.entity.ts#L49

They don't have `nullable: true`, this make typing easier for user of sdk.