### PR TITLE
No allowing user to set .external when create LBID

### DIFF
--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -285,7 +285,7 @@ class BusinessService extends Base {
   /**
    * Create a new business ("Lens Business ID").
    */
-  async createOne(business: Omit<Business, "id" | "createdAt" | "updatedAt" | "businessUsers"> & { id?: string }): Promise<Business> {
+  async createOne(business: Omit<Business, "id" | "createdAt" | "updatedAt" | "businessUsers" | "external"> & { id?: string }): Promise<Business> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/businesses`;
     const json = await throwExpected(


### PR DESCRIPTION
`external` should be set by backend.. we might need to return 400 if user tries to set `external`