### PR TITLE
Add .npmignore, fix typo in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+integration-test/
+.vscode/
+.github/
+.swc

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "import": "./dist/index.mjs",
     "default": "./dist/index.mjs"
   },
-  "main": "./dist/index.mj",
+  "main": "./dist/index.mjs",
   "scripts": {
     "test": "npm run lint && npm run check:type && npm run test:unit && npm run test:e2e",
     "test:unit": "jest",


### PR DESCRIPTION
Fix a regression from https://github.com/lensapp/lens-platform-sdk/pull/363

I have removed `files` section in package.json, but didn't add `.npmignore` so `.gitignore` was used, `./dist` was ignored so we end up publish nothing, this PR fixes it by adding the `.npmignore` to include `./dist`.

Also fix a typo in package.json