### PR TITLE
Fixing missing type definition for the published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "default": "./dist/index.mjs"
   },
   "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "test": "npm run lint && npm run check:type && npm run test:unit && npm run test:e2e",
     "test:unit": "jest",


### PR DESCRIPTION
Regression from https://github.com/lensapp/lens-platform-sdk/pull/363

Editor's typescript server can't find type definition..

It seems necessary to add `types` if `main` is defined in package.json, from https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html
```
If your package has a main .js file, you will need to indicate the main declaration file in your package.json file as well. Set the types property to point to your bundled declaration file.
```