### PR TITLE
Don't add type:module to esm output to avoid `webpack@5` exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "npm run build:dist",
     "build:dist": "rm -rf dist && run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\": \"module\"}'> dist/esm/package.json"
+    "build:esm": "tsc -p tsconfig.esm.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`webpack@5` has `resolve.fullySpecified` default to `true` https://webpack.js.org/configuration/module/#resolvefullyspecified, this causes some issues for sdk users as our `esm` build is with `{ type: module }` but not fully follow the `esm` module spec, `webpack@5` will throw errors when a dependencies is with `{ type: module }` but not following node.js's `esm` module spec.

This PR remove adding `{ type: module }` to esm output, so we can avoid `webpack@5` exceptions.

Needed for https://github.com/lensapp/lenscloud/pull/2224