### PR TITLE
Test against node@16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       TOKEN_HOST: ${{ secrets.TOKEN_HOST }}
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [16, 18]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v3


### PR DESCRIPTION
Because lenscloud and lens are still using 16.