### PR TITLE
Omit subscription id from creating

### DIFF
--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -74,6 +74,11 @@ export type Business = {
    * The department name of the business
    */
   department: string;
+
+  /**
+   * Recurly subscription ID for businesses migrated from Recurly.
+   */
+  businessIdLiteSubscriptionId: string | null;
 };
 
 /**

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -78,7 +78,7 @@ export type Business = {
   /**
    * Recurly subscription ID for businesses migrated from Recurly.
    */
-  businessIdLiteSubscriptionId: string | null;
+  businessIdLiteSubscriptionId: string | null | undefined;
 };
 
 /**

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -385,11 +385,10 @@ class BusinessService extends Base {
    */
   async disableBusinessLightActivationLink(
     id: string,
-    business: DisableBusinessLightActivationLink,
   ): Promise<Business> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
-    const url = `${apiEndpointAddress}/businesses/${id}`;
-    const json = await throwExpected(async () => fetch.patch(url, business), {
+    const url = `${apiEndpointAddress}/businesses/${id}/activation-link`;
+    const json = await throwExpected(async () => fetch.patch(url), {
       400: (error) => new BadRequestException(error?.body.message),
       422: (error) => new UnprocessableEntityException(error?.body.message),
       401: (error) => new UnprocessableEntityException(error?.body.message),

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -269,11 +269,6 @@ export type BusinessUpdate = Omit<
   "id" | "createdAt" | "updatedAt" | "businessUsers" | "external" | "businessIdLiteSubscriptionId"
 >;
 
-export type DisableBusinessLightActivationLink = Omit<
-  Business,
-  "id" | "createdAt" | "updatedAt" | "businessUsers" | "external"
->;
-
 export type BusinessInvitation = {
   /**
    * The business invitation ID

--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -378,9 +378,7 @@ class BusinessService extends Base {
   /**
    * Disable business light activation link
    */
-  async disableBusinessLightActivationLink(
-    id: string,
-  ): Promise<Business> {
+  async disableBusinessLightActivationLink(id: string): Promise<Business> {
     const { apiEndpointAddress, fetch } = this.lensPlatformClient;
     const url = `${apiEndpointAddress}/businesses/${id}/activation-link`;
     const json = await throwExpected(async () => fetch.patch(url), {


### PR DESCRIPTION
As the property is optional, used only in legacy businesses it's better to omit it from existing methods. 