### PR TITLE
Export schema as value not type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,13 +76,20 @@ export type {
   BusinessSsoSamlDto,
   BusinessSsoOidcDto,
   CloudNotification,
-  cloudNotificationsSchema,
   LensCloudNotification,
-  lensCloudNotificationsSchema,
   severityLevels,
   notificationKind,
 };
 export type { LensPlatformClientType, LensPlatformClientOptions };
-export { LensPlatformClient, Roles, Actions, K8sClusterActions, Permissions, TeamActions, SSOType };
-
+export {
+  LensPlatformClient,
+  Roles,
+  Actions,
+  K8sClusterActions,
+  Permissions,
+  TeamActions,
+  SSOType,
+  cloudNotificationsSchema,
+  lensCloudNotificationsSchema,
+};
 export * as Constants from "./data";


### PR DESCRIPTION
So `zod` can use it at runtime.