### PR TITLE
Drop the need to SSO certificate for SAML

### DIFF
--- a/src/BusinessService.ts
+++ b/src/BusinessService.ts
@@ -406,10 +406,6 @@ export interface BusinessSsoSamlDto {
    */
   idpEntityId: string;
   /**
-   * IDP certificate
-   */
-  certificate: string;
-  /**
    * SAML SSO type
    */
   type: SSOType.SAML;


### PR DESCRIPTION
See https://github.com/lensapp/lenscloud/issues/3595

It's not in used at all and create extra complexity (bugs).